### PR TITLE
Adding www.tools.culture.gov.uk to whitelist

### DIFF
--- a/data/whitelist.txt
+++ b/data/whitelist.txt
@@ -157,6 +157,7 @@ www.talentretention.biz
 www.tan.gov.uk
 www.taxdisc.direct.gov.uk
 www.tfl.gov.uk
+www.tools.culture.gov.uk
 www.transportdirect.info
 www.transportoffice.gov.uk
 www.tsoshop.co.uk


### PR DESCRIPTION
To support redirects to https://www.tools.culture.gov.uk/payments/onlinepayments_pt1.aspx and another tool.
