### PR TITLE
BusinessLink-specific TNA link test

### DIFF
--- a/tools/test_bl_410_tna.pl
+++ b/tools/test_bl_410_tna.pl
@@ -29,16 +29,21 @@ while ( my $row = $csv->getline_hr( $fh ) ) {
 	my $status = $row->{'Status'};
 
 	if ( $status == 410 ) {
-		# fetch Old Url from The National Archives
 		my $tna_url = "http://webarchive.nationalarchives.gov.uk/20120823131012/${old_url}";
 
 		my $request = HTTP::Request->new('GET', $tna_url);
-		my $ua = LWP::UserAgent->new(max_redirect => 0);
+		my $ua = LWP::UserAgent->new(max_redirect => 1);
 		my $response = $ua->request($request);
 		my $tna_status = $response->code;
 
 		if ( $tna_status == 404 ) {
 			print "$old_url,$new_url,$status,$tna_status\n";
+		}
+		elsif ( $tna_status == 200 ) {
+			my $response_body = $response->content;
+			if ( $response_body =~ /location\.replace/) {
+				print "$old_url,$new_url,$status,Location is replaced\n";
+			}
 		}
 	}
 }


### PR DESCRIPTION
I created a test specifically for the BusinessLink URLs and the issue with TNA replacing the location and redirecting to a 404.

However, it wouldn't be too much work to make this test accept a parameter of the TNA timestamp and be able to be run for all of the existing mappings, hence the pull request.

I thought there was a story for testing the TNA links but I can't find one, so no story reference (sorry Brad).
