### PR TITLE
Escape commas in urls in whitehall mappings file

### DIFF
--- a/munge/generate-redirects.sh
+++ b/munge/generate-redirects.sh
@@ -63,7 +63,7 @@ if [ -n "$fetch" ]; then
     mkdir -p $(dirname "$whitehall")
     [ -s "$whitehall" ] || rm -f "$whitehall"
     set -x
-    curl -s -u "$user" "$whitehall_url" -z "$whitehall" -o "$whitehall"
+    curl -s -u "$user" "$whitehall_url" | tools/escape_commas_in_urls > "${whitehall}"
     set +x
 
     echo "Fetching mappings for $site ..."

--- a/tests/tools/escape_commas_in_urls_test.rb
+++ b/tests/tools/escape_commas_in_urls_test.rb
@@ -1,0 +1,50 @@
+require 'minitest/unit'
+require 'minitest/autorun'
+require 'open3'
+
+class EscapeCommasInUrlsTest < MiniTest::Unit::TestCase
+  def test_headings_are_preserved
+    lines = invoke("escape_commas_in_urls", ['Old Url,New Url,Status,Stuff'])
+    assert_equal ['Old Url,New Url,Status,Stuff'], lines
+  end
+
+  def test_additional_fields_are_preserved
+    lines = invoke("escape_commas_in_urls", [
+      'Old Url,New Url,Status,Stuff',
+      ',,,Some random stuff'
+    ])
+    assert_equal ',,,Some random stuff', lines[1]
+  end
+
+  def test_commas_in_old_url_are_escaped
+    lines = invoke("escape_commas_in_urls", [
+      'Old Url,New Url,Status,Stuff',
+      '"http://example.com/1,2",,TNA'
+      ])
+    assert_equal 2, lines.size
+    assert_equal "http://example.com/1%2C2,,TNA", lines[1]
+  end
+
+  def test_commas_in_new_url_are_escaped
+    lines = invoke("escape_commas_in_urls", [
+      'Old Url,New Url,Status,Stuff',
+      ',"http://example.com/1,2",TNA'
+      ])
+    assert_equal 2, lines.size
+    assert_equal ",http://example.com/1%2C2,TNA", lines[1]
+  end
+
+  #
+  #  helper functions
+  #
+  def invoke(cmd, stdin, args = {})
+    stdin = [*stdin].join("\n")
+    cmd = File.dirname(__FILE__) + "/../../tools/" + cmd
+    args.each do |argname, argvalue|
+      cmd << " --#{argname} #{argvalue}"
+    end
+    stdout, stderr, status = Open3.capture3(cmd, stdin_data: stdin)
+    raise stderr unless status.exitstatus == 0
+    stdout.split("\n")
+  end
+end

--- a/tools/escape_commas_in_urls
+++ b/tools/escape_commas_in_urls
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require 'CSV'
+
+CSV.new(STDIN, headers: false).each.with_index do |row, i|
+  if i > 0
+    row[0] = row[0].gsub(',', '%2C') if row[0]
+    row[1] = row[1].gsub(',', '%2C') if row[1]
+  end
+  puts row.to_csv
+end


### PR DESCRIPTION
Some urls in whitehall mappings contain commas. Although a comma is a
valid character in a url path[1] the commas cause problems with the rest
of the munge/redirector processing pipeline.

In particular this addresses issues that have arisen with processing the MOJ mappings:

https://www.pivotaltracker.com/story/show/47517313

[1] http://tools.ietf.org/html/rfc3986#section-3.3
