### PR TITLE
Fix error reporting in the TidyMappingsTest

### DIFF
--- a/tests/tools/tidy_mappings_test.rb
+++ b/tests/tools/tidy_mappings_test.rb
@@ -211,7 +211,7 @@ class TidyMappingsTest < MiniTest::Unit::TestCase
     if args[:trump]
       cmd << " --trump"
     end
-    stdout, @stderr, status = Open3.capture3(cmd, stdin_data: stdin)
+    stdout, stderr, status = Open3.capture3(cmd, stdin_data: stdin)
     if status.exitstatus != 0
       puts stderr
     end


### PR DESCRIPTION
`tools/tidy_mappings.pl` is failing on OS X, but we couldn't see the real failure because of this typo.
