### PR TITLE
Remove gone.css check

### DIFF
--- a/tools/test_static_assets.sh
+++ b/tools/test_static_assets.sh
@@ -53,7 +53,6 @@ ls -1 $sites/*.yml |
         echo "http://$host/robots.txt,,200"
         echo "http://$host/sitemap.xml,,200"
         echo "http://$host/favicon.ico,,200"
-        echo "http://$host/gone.css,,200"
 
         echo "http://$host/404,,404"
         echo "http://$host/410,,410"


### PR DESCRIPTION
This will let us run the smokey tests against either redirector or bouncer,
because bouncer serves gone.css from stylesheets/gone.css rather than /gone.css
