### PR TITLE
Line titles up with Whitehall

### DIFF
--- a/data/sites/bis.yml
+++ b/data/sites/bis.yml
@@ -3,7 +3,7 @@ site: bis
 host: www.bis.gov.uk
 redirection_date: 13th December 2012
 tna_timestamp: 20121212135622
-title: Department for Business&#44; Innovation and Skills
+title: Department for Business&#44; Innovation & Skills
 furl: www.gov.uk/bis
 homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
 css: department-for-business-innovation-skills

--- a/data/sites/bis_dius.yml
+++ b/data/sites/bis_dius.yml
@@ -3,7 +3,7 @@ site: bis_dius
 host: www.dius.gov.uk
 redirection_date: 13th December 2012
 tna_timestamp: 20121212135622
-title: Department for Business&#44; Innovation and Skills
+title: Department for Business&#44; Innovation & Skills
 furl: www.gov.uk/bis
 homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
 css: department-for-business-innovation-skills

--- a/data/sites/bis_lowpay.yml
+++ b/data/sites/bis_lowpay.yml
@@ -3,7 +3,7 @@ site: bis_lowpay
 host: www.lowpay.gov.uk
 redirection_date: 25th September 2013
 tna_timestamp: 20130626202215
-title: Lowpay Commission
+title: Low Pay Commission
 furl: www.gov.uk/lowpay
 homepage: https://www.gov.uk/government/organisations/low-pay-commission
 options: 

--- a/data/sites/dcms.yml
+++ b/data/sites/dcms.yml
@@ -3,7 +3,7 @@ site: dcms
 host: www.culture.gov.uk
 redirection_date: 28th February 2013
 tna_timestamp: 20121204113822
-title: Department for Culture&#44; Media and Sport
+title: Department for Culture&#44; Media & Sport
 furl: www.gov.uk/dcms
 homepage: https://www.gov.uk/government/organisations/department-for-culture-media-sport
 aliases:

--- a/data/sites/decc.yml
+++ b/data/sites/decc.yml
@@ -3,7 +3,7 @@ site: decc
 host: www.decc.gov.uk
 redirection_date: 23rd January 2013
 tna_timestamp: 20121217150421
-title: Department of Energy and Climate Change
+title: Department of Energy & Climate Change
 furl: www.gov.uk/decc
 homepage: https://www.gov.uk/government/organisations/department-of-energy-climate-change
 options: --query-string filepath

--- a/data/sites/decc_ceo.yml
+++ b/data/sites/decc_ceo.yml
@@ -3,7 +3,7 @@ site: decc_ceo
 host: ceo.decc.gov.uk
 redirection_date: 23rd January 2013
 tna_timestamp: 20121220093401
-title: Department of Energy and Climate Change
+title: Department of Energy & Climate Change
 furl: www.gov.uk/decc
 homepage: https://www.gov.uk/community-energy
 css: department-of-energy-climate-change

--- a/data/sites/decc_coal.yml
+++ b/data/sites/decc_coal.yml
@@ -3,7 +3,7 @@ site: decc_coal
 host: coal.decc.gov.uk
 redirection_date: 1st January 2014
 tna_timestamp: 20130503104251
-title: Department of Energy and Climate Change
+title: Department of Energy & Climate Change
 furl: www.gov.uk/decc
 homepage: https://www.gov.uk/government/organisations/the-coal-authority
 css: department-of-energy-climate-change

--- a/data/sites/decc_corwm.yml
+++ b/data/sites/decc_corwm.yml
@@ -3,7 +3,7 @@ site: decc_corwm
 host: corwm.decc.gov.uk
 redirection_date: 30th August 2013
 tna_timestamp: 20130503173700
-title: Department of Energy and Climate Change
+title: Department of Energy & Climate Change
 furl: www.gov.uk/corwm
 homepage: https://www.gov.uk/government/organisations/committee-on-radioactive-waste-management
 css: department-of-energy-climate-change

--- a/data/sites/decc_mrws.yml
+++ b/data/sites/decc_mrws.yml
@@ -3,7 +3,7 @@ site: decc_mrws
 host: mrws.decc.gov.uk
 redirection_date: 23rd January 2013
 tna_timestamp: 20121217150421
-title: Department of Energy and Climate Change
+title: Department of Energy & Climate Change
 furl: www.gov.uk/decc
 homepage: https://www.gov.uk/government/policies/managing-the-use-and-disposal-of-radioactive-and-nuclear-substances-and-waste
 css: department-of-energy-climate-change

--- a/data/sites/decc_offshoresea.yml
+++ b/data/sites/decc_offshoresea.yml
@@ -3,7 +3,7 @@ site: decc_offshoresea
 host: www.offshore-sea.org.uk
 redirection_date: 17th May 2013
 tna_timestamp: 20130103064208
-title: Department of Energy and Climate Change
+title: Department of Energy & Climate Change
 furl: www.gov.uk/decc
 homepage: https://www.gov.uk/offshore-energy-strategic-environmental-assessment-sea-an-overview-of-the-sea-process
 options: --query-string faqID:link:categoryID:documentID:pageNumber:fileID:meetingID:bookID:consultationID:productID:downloadID:newsID

--- a/data/sites/decc_og.yml
+++ b/data/sites/decc_og.yml
@@ -3,7 +3,7 @@ site: decc_og
 host: og.decc.gov.uk
 redirection_date: 23rd January 2013
 tna_timestamp: 20121217150421
-title: Department of Energy and Climate Change
+title: Department of Energy & Climate Change
 furl: www.gov.uk/decc
 homepage: https://www.gov.uk/government/organisations/department-of-energy-climate-change
 css: department-of-energy-climate-change

--- a/data/sites/defra.yml
+++ b/data/sites/defra.yml
@@ -3,7 +3,7 @@ site: defra
 host: www.defra.gov.uk
 redirection_date: 10th April 2013
 tna_timestamp: 20130128102031
-title: Department for Environment&#44; Food and Rural Affairs
+title: Department for Environment&#44; Food & Rural Affairs
 furl: www.gov.uk/defra
 homepage: https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs
 css: department-for-environment-food-rural-affairs

--- a/data/sites/oag.yml
+++ b/data/sites/oag.yml
@@ -3,7 +3,7 @@ site: oag
 host: www.oag.gov.uk
 redirection_date: 27th February 2013
 tna_timestamp: 20121105225103
-title: Advocate General for Scotland
+title: Office of the Advocate General for Scotland
 furl: www.gov.uk/oag
 homepage: https://www.gov.uk/government/organisations/office-of-the-advocate-general-for-scotland
 aliases:


### PR DESCRIPTION
In order for [transition](https://github.com/alphagov/transition) to infer Whitehall slugs,
we need to key on title. This corrects the few titles that are out of sync with Whitehall.
