### PR TITLE
Make official documents part of TNA

### DIFF
--- a/data/sites/tna_offdocs.yml
+++ b/data/sites/tna_offdocs.yml
@@ -3,7 +3,7 @@ site: tna_offdocs
 host: www.official-documents.gov.uk
 redirection_date: 6th January 2014 	
 tna_timestamp: 20130814142233
-title: Official Documents
+title: The National Archives
 furl: www.gov.uk/offdocs									
 homepage: https://www.gov.uk/government/organisations/the-national-archives
 aliases:															

--- a/data/sites/tna_offdocsarchive.yml
+++ b/data/sites/tna_offdocsarchive.yml
@@ -3,7 +3,7 @@ site: tna_offdocsarchive
 host: www.archive.official-documents.co.uk
 redirection_date: 6th January 2014 	
 tna_timestamp: 20130908025043 				
-title: Official Documents
+title: The National Archives
 furl: www.gov.uk/offdocs									
 homepage: https://www.gov.uk/government/organisations/the-national-archives
 ---

--- a/data/sites/tna_offdocsarchive2.yml
+++ b/data/sites/tna_offdocsarchive2.yml
@@ -3,7 +3,7 @@ site: tna_offdocsarchive2
 host: www.archive2.official-documents.co.uk
 redirection_date: 6th January 2014 	
 tna_timestamp: 20130814142233 				
-title: Official Documents
+title: The National Archives
 furl: www.gov.uk/offdocs									
 homepage: https://www.gov.uk/government/organisations/the-national-archives
 ---


### PR DESCRIPTION
Transition keys on site title to determine whether something is an
org in its own right. These sites aren't, so we need to make them
subordinate to TNA, otherwise we end up with three 
"Official Documents" orgs in our root org list.
