### PR TITLE
Fix problematic tabs in sites.yml and script

### DIFF
--- a/data/sites/tna_offdocs.yml
+++ b/data/sites/tna_offdocs.yml
@@ -1,11 +1,11 @@
 ---
 site: tna_offdocs
 host: www.official-documents.gov.uk
-redirection_date: 6th January 2014 	
+redirection_date: 6th January 2014   
 tna_timestamp: 20130814142233
 title: The National Archives
-furl: www.gov.uk/offdocs									
+furl: www.gov.uk/offdocs                  
 homepage: https://www.gov.uk/government/organisations/the-national-archives
-aliases:															
+aliases:                              
   - www.official-documents.co.uk
 ---

--- a/data/sites/tna_offdocsarchive.yml
+++ b/data/sites/tna_offdocsarchive.yml
@@ -1,9 +1,9 @@
 ---
 site: tna_offdocsarchive
 host: www.archive.official-documents.co.uk
-redirection_date: 6th January 2014 	
-tna_timestamp: 20130908025043 				
+redirection_date: 6th January 2014   
+tna_timestamp: 20130908025043         
 title: The National Archives
-furl: www.gov.uk/offdocs									
+furl: www.gov.uk/offdocs                  
 homepage: https://www.gov.uk/government/organisations/the-national-archives
 ---

--- a/data/sites/tna_offdocsarchive2.yml
+++ b/data/sites/tna_offdocsarchive2.yml
@@ -1,9 +1,9 @@
 ---
 site: tna_offdocsarchive2
 host: www.archive2.official-documents.co.uk
-redirection_date: 6th January 2014 	
-tna_timestamp: 20130814142233 				
+redirection_date: 6th January 2014   
+tna_timestamp: 20130814142233         
 title: The National Archives
-furl: www.gov.uk/offdocs									
+furl: www.gov.uk/offdocs                  
 homepage: https://www.gov.uk/government/organisations/the-national-archives
 ---

--- a/data/sites/treasury_tsol.yml
+++ b/data/sites/treasury_tsol.yml
@@ -2,9 +2,9 @@
 site: treasury_tsol
 host: www.tsol.gov.uk
 redirection_date: 11th December, 2013
-tna_timestamp: 20130704203515 				
-title: Treasury Solicitor's Department									
-furl: www.gov.uk/tsol									
+tna_timestamp: 20130704203515         
+title: Treasury Solicitor's Department                  
+furl: www.gov.uk/tsol                  
 homepage: https://www.gov.uk/government/organisations/treasury-solicitor-s-department
 css: treasury
 ---

--- a/tools/new_site.sh
+++ b/tools/new_site.sh
@@ -9,14 +9,14 @@ touch $site
 echo "---" >> $site
 echo "site: $1" >> $site
 echo "host: $2" >> $site
-echo "redirection_date: 21st February 2013 	# Full text date here" >> $site
-echo "tna_timestamp: 20130128101412 				# Best TNA timestamp here" >> $site
-echo "title: Cabinet Office									# Title of organisation here" >> $site
-echo "furl: www.gov.uk/$1									# Furl for print display here" >> $site
+echo "redirection_date: 21st February 2013  # Full text date here" >> $site
+echo "tna_timestamp: 20130128101412         # Best TNA timestamp here" >> $site
+echo "title: Cabinet Office                 # Title of organisation here" >> $site
+echo "furl: www.gov.uk/$1                   # Furl for print display here" >> $site
 echo "homepage: https://www.gov.uk/government/organisations/$1" >> $site
-echo "																			# Organisation landing page here" >> $site
-echo "css: cabinet-office										# Appropriate CSS here" >> $site
-echo "aliases:															# Aliases for $2 domain here" >> $site
+echo "                                      # Organisation landing page here" >> $site
+echo "css: cabinet-office                   # Appropriate CSS here" >> $site
+echo "aliases:                              # Aliases for $2 domain here" >> $site
 echo "  - www.dclg.gov.uk" >> $site
 echo "  - www.communities.gov.uk" >> $site
 echo "options: --query-string title:attachment" >> $site


### PR DESCRIPTION
The tabs were causing some YAML parsers to fail. Specifically, it meant the CDN configuration script couldn't configure the CDN. Replacing them with spaces solves that problem. I'm assuming the trailing whitespace won't cause problems in the redirector app.
