### PR TITLE
Remove trailing newline from ruralcommunities tests

### DIFF
--- a/data/tests/www.ruralcommunities.gov.uk.csv
+++ b/data/tests/www.ruralcommunities.gov.uk.csv
@@ -1,3 +1,2 @@
 Old Url,New Url,Status
 http://www.ruralcommunities.gov.uk,,410
-


### PR DESCRIPTION
To fix build errors like [this](https://deploy.preview.alphagov.co.uk/job/Preview_Redirector_Smokey/652/console)
