### PR TITLE
Associate the UKBA sites with UKVI

### DIFF
--- a/data/transition-sites/ukvi.yml
+++ b/data/transition-sites/ukvi.yml
@@ -1,12 +1,11 @@
 ---
-site: ukba
-whitehall_slug: uk-border-agency
+site: ukvi
+whitehall_slug: uk-visas-and-immigration
 host: www.ukba.homeoffice.gov.uk
 redirection_date: 11th February 2014
 tna_timestamp: 20130925160031
-title: UK Border Agency
-furl: www.gov.uk/ukba
-homepage: https://www.gov.uk/government/organisations/uk-border-agency
+title: UK Visas and Immigration
+homepage: https://www.gov.uk/government/organisations/uk-visas-and-immigration
 aliases:
 - bia.homeoffice.gov.uk
 - ind.homeoffice.gov.uk

--- a/data/transition-sites/ukvi_lifeintheuktest.yml
+++ b/data/transition-sites/ukvi_lifeintheuktest.yml
@@ -1,11 +1,10 @@
 ---
-site: ukba_lifeintheuktest
-whitehall_slug: uk-border-agency
+site: ukvi_lifeintheuktest
+whitehall_slug: uk-visas-and-immigration
 host: lifeintheuktest.ukba.homeoffice.gov.uk
 redirection_date:
 tna_timestamp: 20130919230248
-title: UK Border Agency
-furl: www.gov.uk/ukba
+title: UK Visas and Immigration
 homepage: https://www.gov.uk/book-life-in-uk-test
 aliases:
 - www.lifeintheuktest.gov.uk


### PR DESCRIPTION
UKVI has replaced UKBA for 90% of its function, so it is the most helpful place to send users to if they hit a 404/410.

This change will need to be applied by hand to the Transition database, as the import can't handle this kind of change.
