### PR TITLE
Add all known EA querystrings for Flood Warnings

### DIFF
--- a/data/transition-sites/ea.yml
+++ b/data/transition-sites/ea.yml
@@ -7,3 +7,6 @@ furl: www.gov.uk/environment-agency
 homepage: https://www.gov.uk/government/organisations/environment-agency
 tna_timestamp: 20131203145522
 host: www.environment-agency.gov.uk
+# Currently just known querystrings parameters used on:
+# http://www.environment-agency.gov.uk/homeandleisure/floods/34678.aspx
+options: --query-string from:latest:page:pubdate:ref:severity:style:term:title:type


### PR DESCRIPTION
Please don't merge without speaking to me first. I'd like to use the logs to expand and check this list first.

Before I implement a rule for the Flood Warnings in Bouncer, I'd like to prevent a gotcha with mappings for those URLs.

These are all of the EA querystrings we currently know about in use on Flood Warnings.

We don't intend to write mappings for these URLs, we will have a rule. However, because mappings are evaluated before rules, we want to make sure that if someone did create rules for these URLs that they wouldn't be canonicalised such that it would map all of these URLs.

Basically, for EA Flood Warnings, we always want the rule. Adding these significant querystring parameters is a safeguard.
