### PR TITLE
Automatically fetch TNA Timestamp for a new site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rake', '10.0.3'
 gem 'minitest', '4.7.0'
+gem 'nokogiri', '1.6.1'
 gem 'htmlentities', '4.3.1'
 gem 'gds-api-adapters', '7.22.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,10 @@ GEM
     lrucache (0.1.4)
       PriorityQueue (~> 0.1.2)
     mime-types (2.0)
+    mini_portile (0.5.2)
     minitest (4.7.0)
+    nokogiri (1.6.1)
+      mini_portile (~> 0.5.0)
     null_logger (0.0.1)
     plek (1.5.0)
     rake (10.0.3)
@@ -34,5 +37,6 @@ DEPENDENCIES
   gds-api-adapters (= 7.22.0)
   htmlentities (= 4.3.1)
   minitest (= 4.7.0)
+  nokogiri (= 1.6.1)
   rake (= 10.0.3)
   webmock

--- a/lib/redirector/site.rb
+++ b/lib/redirector/site.rb
@@ -1,6 +1,7 @@
 require 'yaml'
 require 'htmlentities'
 require 'redirector/slugs_missing_exception'
+require 'redirector/tna_timestamp'
 
 module Redirector
   class Site
@@ -48,6 +49,14 @@ module Redirector
       hash['host']
     end
 
+    def tna_timestamp
+      if timestamp = Redirector::TNATimestamp.new(host).find
+        timestamp.to_i
+      else
+        nil
+      end
+    end
+
     def filename
       File.expand_path("../../data/#{sites_path}/#{abbr}.yml", File.dirname(__FILE__))
     end
@@ -74,7 +83,7 @@ module Redirector
         'title'            => Site.coder.encode(title),
         'redirection_date' => '31st October 2014',
         'homepage'         => "https://www.gov.uk/government/organisations/#{whitehall_slug}",
-        'tna_timestamp'    => 20201205150354,
+        'tna_timestamp'    => tna_timestamp,
         'host'             => host,
         'furl'             => "www.gov.uk/#{abbr}",
         'aliases'          => %W(www1.#{host} www2.#{host}),

--- a/lib/redirector/tna_timestamp.rb
+++ b/lib/redirector/tna_timestamp.rb
@@ -1,0 +1,25 @@
+require 'open-uri'
+require 'nokogiri'
+
+module Redirector
+  class TNATimestamp
+    def initialize(hostname)
+      @hostname = hostname
+    end
+
+    def find
+      begin
+        response = open("http://webarchive.nationalarchives.gov.uk/*/http://#{@hostname}")
+      rescue OpenURI::HTTPError
+        $stderr.puts("TNA don't appear to have crawled this (yet) #{@hostname} Try the aliases?")
+        return nil
+      end
+
+      doc = Nokogiri::HTML(response)
+      crawl_date_row = doc.css('div#pagemain table tr').last
+      most_recent_crawl_link = crawl_date_row.css('td a').last
+      url = URI.parse(most_recent_crawl_link['href'])
+      url.path.split('/')[1]
+    end
+  end
+end

--- a/tests/fixtures/tna/ukba.html
+++ b/tests/fixtures/tna/ukba.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <head>
+    <title>Internet Memory | UK Government Web Archive</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <link href="/media/css/tna.css" type="text/css" rel="stylesheet" media="all" />
+  </head>
+  <body>
+    <div id="header">
+      <a name="top"></a>
+      <div id="logo">
+        <a title="The National Archives" href="http://www.nationalarchives.gov.uk" target="_top"><img src="/media/img/logo_TNA_201005.gif" height="46" width="317" alt="The National Archives" /></a>
+      </div>
+    </div>
+
+    <div id="pagecontent">
+      <h1>UK Government Web Archive</h1>
+      <div id="searchZone">
+        <style>
+          #maintenance-warning h3 {
+          font-size: 13px;
+          }
+        </style>
+      We currently have a problem with our search facility, making it slower than
+      usual to return results. We’re working on a solution. Please accept our
+      apologies for any inconvenience.
+        <form id="search" action="http://webarchive.nationalarchives.gov.uk/search/" method="get" target="_top">
+          <fieldset class="left">
+            <div id="search-text">
+              <input class="textField" name="query" type="text" onfocus="if (this.value==this.defaultValue) this.value='';" size="50" value="Search the UK Government Web Archive" />
+            </div>
+            <div id="select-box">
+              <select name="where" class="selectField">
+                <option class="select-text" value="text">the Collection</option>
+                <option class="select-text" value="url" selected>the URLs</option>
+              </select>
+            </div>
+            <div id="search-submit">
+              <input type="image" value="submit" alt="submit" src="/media/img/search.gif" />
+            </div>
+          </fieldset>
+          <fieldset class="right">
+            <div class="search-links"><a href="http://webarchive.nationalarchives.gov.uk/adv_search/">Advanced Search</a></div>
+           </fieldset>
+        </form>
+      </div>
+      <div id="pagemain">
+        <h2>  [ live site <a href="http://www.ukba.homeoffice.gov.uk" title="" target="_blank">http://www.ukba.homeoffice.gov.uk</a> ]</h2>
+        <p></p>
+        <table>
+        <tr>
+          <td colspan="7" class="header">
+            <div id="searchTitle">
+              <div id="searchDesc">Search results for Aug 06 2008 - Jan 10 2014 </div>
+              <div id="searchResult">[263 results]</div>
+            <div>
+          </td>
+        </tr>
+          <div id="tblcontainer">
+            <tr>
+              <th>2013<br /><span class="small">[ 1 instances]</span></th>
+              <th>2014<br /><span class="small">[ 2 instances]</span></th>
+            </tr>
+            <tr>
+              <td nowrap>
+                <a href="http://webarchive.nationalarchives.gov.uk/20131202165031/http://www.ukba.homeoffice.gov.uk" class="">Dec 02 2013</a><br/>
+              </td>
+              <td nowrap>
+                <a href="http://webarchive.nationalarchives.gov.uk/20140107122627/http://www.ukba.homeoffice.gov.uk" class="">Jan 07 2014</a><br/>
+                <a href="http://webarchive.nationalarchives.gov.uk/20140110181512/http://www.ukba.homeoffice.gov.uk" class="">Jan 10 2014</a><br/>
+              </td>
+            </tr>
+          </div>
+        </table>
+      </div>
+    </div>
+    <div id="footer">
+      <a href="http://europarchive.org/about.php">About</a> | <a href=mailto:info@europarchive.org>Contact</a> |
+      <a href="http://europarchive.org/terms.php">Terms, Privacy & Copyright</a><br />
+    </div>
+  </body>
+</html>

--- a/tests/lib/redirector/site_test.rb
+++ b/tests/lib/redirector/site_test.rb
@@ -116,6 +116,10 @@ class RedirectorSiteTest < MiniTest::Unit::TestCase
   end
 
   def test_site_creates_bouncer_yaml_when_slug_exists
+    tna_response = File.read(relative_to_tests('fixtures/tna/ukba.html'))
+    stub_request(:get, "http://webarchive.nationalarchives.gov.uk/*/http://www.ukba.homeoffice.gov.uk").
+        to_return(status: 200, body: tna_response)
+
     organisation_details = organisation_details_for_slug('uk-borders-agency').tap do |details|
       details['title'] = 'UK Borders Agency & encoding test'
     end
@@ -140,6 +144,7 @@ class RedirectorSiteTest < MiniTest::Unit::TestCase
       assert_equal 'uk-borders-agency', yaml['whitehall_slug']
       assert_equal 'UK Borders Agency &amp; encoding test', yaml['title']
       assert_equal 'https://www.gov.uk/government/organisations/uk-borders-agency', yaml['homepage']
+      assert_equal 20140110181512, yaml['tna_timestamp']
     ensure
       File.delete(site.filename)
     end


### PR DESCRIPTION
Scrape the TNA Web Archive and extract the most recent crawl automatically.

If it doesn't find a timestamp, it will warn about the problem but leave it empty. It does therefore put a burden on the person generating the site(s) to manually put _something_ in there, otherwise transition won't import it.
