### PR TITLE
Configure SFA Root domains

### DIFF
--- a/tld/learningrecordsservice.org.uk
+++ b/tld/learningrecordsservice.org.uk
@@ -1,0 +1,4 @@
+server {
+  server_name learningrecordsservice.org.uk;
+  rewrite ^/(.*) http://www.learningrecordsservice.org.uk/$1 permanent;
+}

--- a/tld/skillsfundingagency.bis.gov.uk
+++ b/tld/skillsfundingagency.bis.gov.uk
@@ -1,0 +1,4 @@
+server {
+  server_name skillsfundingagency.bis.gov.uk;
+  rewrite ^/(.*) http://www.skillsfundingagency.bis.gov.uk/$1 permanent;
+}

--- a/tld/thedataservice.org.uk
+++ b/tld/thedataservice.org.uk
@@ -1,0 +1,4 @@
+server {
+  server_name thedataservice.org.uk;
+  rewrite ^/(.*) http://www.thedataservice.org.uk/$1 permanent;
+}

--- a/tld/theia.org.uk
+++ b/tld/theia.org.uk
@@ -1,0 +1,4 @@
+server {
+  server_name theia.org.uk;
+  rewrite ^/(.*) http://www.theia.org.uk/$1 permanent;
+}


### PR DESCRIPTION
Root domains like these can't be CNAMEd directly to us, instead, they must have an A record to an IP address. Therefore we host these at an IP, and the nginx configuration redirects them to the www subdomain which can be/is CNAMEd to us.
