### PR TITLE
procurement.cab... => aka-procurement.cab...

### DIFF
--- a/tld/procurement.cabinetoffice.gov.uk
+++ b/tld/procurement.cabinetoffice.gov.uk
@@ -1,0 +1,4 @@
+server {
+  server_name procurement.cabinetoffice.gov.uk;
+  rewrite ^/(.*) http://aka-procurement.cabinetoffice.gov.uk/$1 permanent;
+}


### PR DESCRIPTION
procurement.cabinetoffice.gov.uk cannot be CNAMEd, so we need to host it at an
IP and redirect to aka-procurement.cabinetoffice.gov.uk which can be CNAMED.

Whilst procurement.cabinetoffice.gov.uk isn't at the root of the DNS zone, it
does have MX records for receiving mail. The DNS specification prevents you
from having both a CNAME and MX record for a domain.

Bouncer will canonicalise aka-procurement.cabinetoffice.gov.uk to procurement.cabinetoffice.gov.uk, so the links to the National Archive should work.
