### PR TITLE
Automate update of webarchive timestamp

### DIFF
--- a/tools/get_webarchive.sh
+++ b/tools/get_webarchive.sh
@@ -6,7 +6,7 @@ domain=$1
 curl http://webarchive.nationalarchives.gov.uk/*/$domain |
   grep -o 'http[^"]*' |
   grep webarchive |
-  grep -o '\d\d\d\d\d\d\d\d\d\d\d\d' |   # odd looking regex to work on both linux and mac unix
+  grep -o '\d\d\d\d\d\d\d\d\d\d\d\d\d\d' |   # odd looking regex to work on both linux and mac unix
   sort |
   tail -1 |
   sed 's/^/Latest\ archive\ crawl\ for\ '$domain':\ /'

--- a/tools/update_webarchive.sh
+++ b/tools/update_webarchive.sh
@@ -1,0 +1,17 @@
+
+#Usage sh update_webarchive.sh subdomain.topleveldomain.gov.uk
+
+site=$1
+getweb=$(find . | grep get_webarchive) # find the tool
+yaml=$(find . | grep $site.yml) # find the yaml
+target=$(
+	sh $getweb $(
+		cat $yaml |
+					grep host |
+					sed 's/host: //'
+					) |
+		grep -o '\d\d\d\d\d\d\d\d\d\d\d\d\d\d'  # odd looking regex to work on both linux and mac unix
+	)
+
+sed 's/tna_timestamp.*/tna_timestamp: '$target'/' $yaml > temp &&
+	mv -f temp $yaml


### PR DESCRIPTION
The bash script that developed this: https://github.com/alphagov/redirector/pull/516

For greater clarity this script will take a site name (as used in redirector) and (a) curl the webarchive for the latest, and (b) update the yaml to include. 

Careful check of the output is important, as always
