### PR TITLE
Change landing page for OffDocs

### DIFF
--- a/data/transition-sites/tna_offdocs.yml
+++ b/data/transition-sites/tna_offdocs.yml
@@ -6,6 +6,6 @@ redirection_date: 3rd March 2014
 tna_timestamp: 20140210084229
 title: The National Archives
 furl: www.gov.uk/offdocs
-homepage: https://www.gov.uk/government/organisations/the-national-archives
+homepage: https://www.gov.uk/government/publications?official_document_status=command_and_act_papers
 aliases:
 - www.official-documents.co.uk

--- a/data/transition-sites/tna_offdocsarchive.yml
+++ b/data/transition-sites/tna_offdocsarchive.yml
@@ -6,4 +6,4 @@ redirection_date: 3rd March 2014
 tna_timestamp: 20140131031506
 title: The National Archives
 furl: www.gov.uk/offdocs
-homepage: https://www.gov.uk/government/organisations/the-national-archives
+homepage: https://www.gov.uk/government/publications?official_document_status=command_and_act_papers

--- a/data/transition-sites/tna_offdocsarchive2.yml
+++ b/data/transition-sites/tna_offdocsarchive2.yml
@@ -6,4 +6,4 @@ redirection_date: 3rd March 2014
 tna_timestamp: 20131205100653
 title: The National Archives
 furl: www.gov.uk/offdocs
-homepage: https://www.gov.uk/government/organisations/the-national-archives
+homepage: https://www.gov.uk/government/publications?official_document_status=command_and_act_papers


### PR DESCRIPTION
www.official-documents.gov.uk is a service site, with users primarily looking for the digital versions of Command and Act papers.

It makes more sense to send users to a pre-filtered list of the types of documents they seek, than the organisation homepage of the documents' exempt parent organisation.
