### PR TITLE
Configure Defra mappings for import to bouncer

### DIFF
--- a/data/mappings/defra.csv
+++ b/data/mappings/defra.csv
@@ -1,5 +1,5 @@
 Old Url,New Url,Status
-http://www.defra.gov.uk/2010,,410
+http://www.defra.gov.uk/2010,http://www.defra.gov.uk/news/2010/,301
 http://www.defra.gov.uk/2010/08/27/bovine-disease-compensation,,410
 http://www.defra.gov.uk/aahm,,410
 http://www.defra.gov.uk/aahm/2011/02/08/disinfectant-listing,,410
@@ -348,6 +348,7 @@ http://www.defra.gov.uk/abstraction-reform/working-with/advisory-group,https://w
 http://www.defra.gov.uk/abstraction-reform/working-with/advisory-group/meetings,https://www.gov.uk/government/policy-advisory-groups/abstraction-reform,301
 http://www.defra.gov.uk/abstraction-reform/working-with/advisory-group/members,https://www.gov.uk/government/policy-advisory-groups/abstraction-reform,301
 http://www.defra.gov.uk/abstraction-reform/working-with/advisory-group/terms-of-reference,https://www.gov.uk/government/policy-advisory-groups/abstraction-reform,301
+http://www.defra.gov.uk/accessibility/index.htm,http://www.defra.gov.uk/corporate/website/accessibility/,301
 http://www.defra.gov.uk/achs/publications,,410
 http://www.defra.gov.uk/acre,https://www.gov.uk/government/organisations/advisory-committee-on-releases-to-the-environment,301
 http://www.defra.gov.uk/acre/about,https://www.gov.uk/government/organisations/advisory-committee-on-releases-to-the-environment/about,301
@@ -410,6 +411,7 @@ http://www.defra.gov.uk/acre/sub-groups,,410
 http://www.defra.gov.uk/acre/sub-groups/env-monitoring,,410
 http://www.defra.gov.uk/acre/sub-groups/new-techniques,,410
 http://www.defra.gov.uk/acre/sub-groups/public-engagement,,410
+http://www.defra.gov.uk/adaptation,http://www.defra.gov.uk/environment/climate/,301
 http://www.defra.gov.uk/ahvla,,410
 http://www.defra.gov.uk/ahvla-cy,,410
 http://www.defra.gov.uk/ahvla-cy/2012/10/01/bluetongue,,410
@@ -3205,6 +3207,8 @@ http://www.defra.gov.uk/bigtreeplant/wp-includes/js/jquery/jquery-migrate.min.js
 http://www.defra.gov.uk/bigtreeplant/wp-includes/js/jquery/jquery.js,,410
 http://www.defra.gov.uk/bigtreeplant/wp-includes/wlwmanifest.xml,,410
 http://www.defra.gov.uk/bigtreeplant/xmlrpc.php,,410
+http://www.defra.gov.uk/blog,http://www.defra.gov.uk/news/,301
+http://www.defra.gov.uk/category,http://www.defra.gov.uk/news/category/,301
 http://www.defra.gov.uk/chemicals-forum,https://www.gov.uk/government/policy-advisory-groups/uk-chemicals-stakeholder-forum,301
 http://www.defra.gov.uk/chemicals-forum/2009/annual-report-2009,,410
 http://www.defra.gov.uk/chemicals-forum/2009/annual-report-2009/feed,https://www.gov.uk/government/policy-advisory-groups/uk-chemicals-stakeholder-forum,301
@@ -3419,6 +3423,9 @@ http://www.defra.gov.uk/consult/2013/03/18/waste-shipment,https://www.gov.uk/gov
 http://www.defra.gov.uk/consult/2013/03/21/triennial-review-jncc-1303,https://www.gov.uk/government/consultations/triennial-review-of-the-joint-nature-conservation-committee,301
 http://www.defra.gov.uk/consult/2013/03/22/bathing-waters-heysham,https://www.gov.uk/government/consultations/bathing-waters-review-2013-heysham-half-moon-bay,301
 http://www.defra.gov.uk/consult/2013/03/27/jam-regs-2013,https://www.gov.uk/government/consultations/jam-and-similar-products-england-regulations-2013,301
+http://www.defra.gov.uk/consult/animal-disease-plan-1103,https://www.gov.uk/government/consultations/annual-review-of-defra-s-contingency-plan-for-exotic-notifiable-diseases-of-animals,301
+http://www.defra.gov.uk/consult/bse-testing-1104,https://www.gov.uk/government/consultations/non-formal-consultation-on-proposed-changes-to-bse-testing-of-cattle-slaughtered-for-human-consumption,301
+http://www.defra.gov.uk/consult/coastal-access-1104,https://www.gov.uk/government/consultations/proposed-regulations-for-appeals-against-works-notices-exclusions-or-restrictions-of-access-and-dedication-of-land,301
 http://www.defra.gov.uk/consult/files/110210-pesticides2011-condoc-enforce-regs.pdf,https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/82269/110210-pesticides2011-condoc-enforce-regs.pdf,301
 http://www.defra.gov.uk/consult/files/110210-pesticides2011-condoc-fees-regs.pdf,https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/82267/110210-pesticides2011-condoc-fees-regs.pdf,301
 http://www.defra.gov.uk/consult/files/110210-pesticides2011-condoc-fees.pdf,https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/82268/110210-pesticides2011-condoc-fees.pdf,301
@@ -4000,7 +4007,11 @@ http://www.defra.gov.uk/consult/files/wpp-consult-letter-20130311.pdf,https://ww
 http://www.defra.gov.uk/consult/files/wpp-consult-list-20130314.pdf,https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/181990/wpp-consult-list-20130314.pdf.pdf,301
 http://www.defra.gov.uk/consult/files/wpp-consult-response-form-20130311.doc,https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/181993/wpp-consult-response-form-20130311.doc.doc,301
 http://www.defra.gov.uk/consult/files/wpp-consult-response-form-20130311.pdf,https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/181994/wpp-consult-response-form-20130311.pdf.pdf,301
+http://www.defra.gov.uk/consult/fisheries-1104,https://www.gov.uk/government/consultations/reform-of-domestic-fisheries-management-arrangements-in-england,301
+http://www.defra.gov.uk/consult/water-affordability-1104,https://www.gov.uk/government/consultations/water-affordability-in-response-to-the-walker-review-of-charging-for-household-water-and-sewerage-services,301
+http://www.defra.gov.uk/consult/waterways-1103,https://www.gov.uk/government/consultations/moving-inland-waterways-into-a-new-charity-in-england-and-wales,301
 http://www.defra.gov.uk/continuity,https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs/about/staff-update,301
+http://www.defra.gov.uk/copyright.htm,http://www.defra.gov.uk/corporate/website/copyright/,301
 http://www.defra.gov.uk/corporate,,410
 http://www.defra.gov.uk/corporate/about,https://www.gov.uk/government/organisations/Department-for-environment-food-rural-affairs/about,301
 http://www.defra.gov.uk/corporate/about/environmental,https://www.gov.uk/government/organisations/Department-for-environment-food-rural-affairs/about/our-energy-use,301
@@ -4014,6 +4025,7 @@ http://www.defra.gov.uk/corporate/about/how/policy-guidance,,410
 http://www.defra.gov.uk/corporate/about/how/policy-guidance/env-impact-guide,https://www.gov.uk/assessing-environmental-impact-guidance,301
 http://www.defra.gov.uk/corporate/about/how/policy-guidance/rural-proofing,https://www.gov.uk/rural-proofing-guidance,301
 http://www.defra.gov.uk/corporate/about/how/policy-guidance/sd-impact,https://www.gov.uk/sustainable-development-impact-test,301
+http://www.defra.gov.uk/corporate/about/how/procurement,http://www.defra.gov.uk/corporate/about/procurement/,301
 http://www.defra.gov.uk/corporate/about/how/regulation,,410
 http://www.defra.gov.uk/corporate/about/how/state-aid,https://www.gov.uk/state-aid-for-agriculture-and-fisheries,301
 http://www.defra.gov.uk/corporate/about/how/state-aid/agri-product,https://www.gov.uk/state-aid-for-agriculture-and-fisheries,301
@@ -4034,9 +4046,12 @@ http://www.defra.gov.uk/corporate/about/who/ministers/paterson,https://www.gov.u
 http://www.defra.gov.uk/corporate/about/who/ministers/transparency,https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs/series/ministers-hospitality-gifts-meetings-overseas-travel,301
 http://www.defra.gov.uk/corporate/about/with,https://www.gov.uk/government/organisations/Department-for-environment-food-rural-affairs/about,301
 http://www.defra.gov.uk/corporate/about/with/a-z,https://www.gov.uk/government/organisations/Department-for-environment-food-rural-affairs/about,301
+http://www.defra.gov.uk/corporate/about/with/delivery,http://www.defra.gov.uk/corporate/about/with/,301
 http://www.defra.gov.uk/corporate/about/with/former-bodies,,410
 http://www.defra.gov.uk/corporate/about/with/ndpb-review,https://www.gov.uk/government/organisations/Department-for-environment-food-rural-affairs/about,301
 http://www.defra.gov.uk/corporate/about/with/public-bodies-reform,,410
+http://www.defra.gov.uk/corporate/consult/animal-disease-plan,http://www.defra.gov.uk/consult/?p=52,301
+http://www.defra.gov.uk/corporate/consult/sewerage,http://www.defra.gov.uk/consult/?p=38,301
 http://www.defra.gov.uk/corporate/contacts,https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs,301
 http://www.defra.gov.uk/corporate/contacts/complaints,https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs/about/complaints-procedure,301
 http://www.defra.gov.uk/corporate/contacts/complaints/access-to-information,https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs/about/complaints-procedure,301
@@ -4049,9 +4064,11 @@ http://www.defra.gov.uk/corporate/contacts/food-farm-qa,,410
 http://www.defra.gov.uk/corporate/contacts/wildlife-pets-qa,,410
 http://www.defra.gov.uk/corporate/docs,https://www.gov.uk/government/organisations/Department-for-environment-food-rural-affairs/about/publication-scheme,301
 http://www.defra.gov.uk/corporate/docs/data,https://www.gov.uk/government/organisations/Department-for-environment-food-rural-affairs/about/publication-scheme,301
+http://www.defra.gov.uk/corporate/environment,http://www.defra.gov.uk/corporate/about/environmental/,301
 http://www.defra.gov.uk/corporate/funding,,410
 http://www.defra.gov.uk/corporate/jobs,https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs/about/recruitment,301
 http://www.defra.gov.uk/corporate/jobs/vacancies,https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs/about/recruitment,301
+http://www.defra.gov.uk/corporate/policy/accessinfo.htm,http://www.defra.gov.uk/corporate/about/how/opengov/,301
 http://www.defra.gov.uk/corporate/website,,410
 http://www.defra.gov.uk/corporate/website/a-z,,410
 http://www.defra.gov.uk/corporate/website/access-info,,410
@@ -4439,6 +4456,7 @@ http://www.defra.gov.uk/ecosystem-markets/wp-includes/js/jquery/jquery.js,,410
 http://www.defra.gov.uk/ecosystem-markets/wp-includes/wlwmanifest.xml,,410
 http://www.defra.gov.uk/ecosystem-markets/xmlrpc.php,,410
 http://www.defra.gov.uk/environment,,410
+http://www.defra.gov.uk/environment/business,http://www.defra.gov.uk/environment/economy/,301
 http://www.defra.gov.uk/environment/climate,https://www.gov.uk/government/policies/adapting-to-climate-change,301
 http://www.defra.gov.uk/environment/climate/a-to-z,,410
 http://www.defra.gov.uk/environment/climate/adapting,https://www.gov.uk/government/policies/adapting-to-climate-change,301
@@ -4570,6 +4588,8 @@ http://www.defra.gov.uk/environment/natural/whitepaper/delivering-ambitions,http
 http://www.defra.gov.uk/environment/natural/whitepaper/local-nature-partnerships/lnp-fund,,410
 http://www.defra.gov.uk/environment/natural/whitepaper/nia,https://www.gov.uk/government/news/natural-environment-white-paper-discussion-document-record-response,301
 http://www.defra.gov.uk/environment/natural/whitepaper/one-year-on,https://www.gov.uk/government/news/natural-environment-white-paper-discussion-document-record-response,301
+http://www.defra.gov.uk/environment/policy/natural-environ,http://www.defra.gov.uk/environment/natural/,301
+http://www.defra.gov.uk/environment/policy/permits,http://www.defra.gov.uk/environment/quality/permitting/,301
 http://www.defra.gov.uk/environment/quality,,410
 http://www.defra.gov.uk/environment/quality/air,,410
 http://www.defra.gov.uk/environment/quality/air/air-quality,https://www.gov.uk/government/policies/protecting-and-enhancing-our-urban-and-natural-environment-to-improve-public-health-and-wellbeing/supporting-pages/international-european-and-national-standards-for-air-quality,301
@@ -4596,6 +4616,7 @@ http://www.defra.gov.uk/environment/quality/air/air-quality/laqm/guidance/others
 http://www.defra.gov.uk/environment/quality/air/air-quality/laqm/guidance/policy,https://www.gov.uk/government/policies/protecting-and-enhancing-our-urban-and-natural-environment-to-improve-public-health-and-wellbeing/supporting-pages/international-european-and-national-standards-for-air-quality,301
 http://www.defra.gov.uk/environment/quality/air/air-quality/science,https://www.gov.uk/government/policies/protecting-and-enhancing-our-urban-and-natural-environment-to-improve-public-health-and-wellbeing/supporting-pages/international-european-and-national-standards-for-air-quality,301
 http://www.defra.gov.uk/environment/quality/air/air-quality/science/research,https://www.gov.uk/government/policies/protecting-and-enhancing-our-urban-and-natural-environment-to-improve-public-health-and-wellbeing/supporting-pages/international-european-and-national-standards-for-air-quality,301
+http://www.defra.gov.uk/environment/quality/air/airquality,http://www.defra.gov.uk/environment/quality/air/air-quality/,301
 http://www.defra.gov.uk/environment/quality/air/fgas,https://www.gov.uk/managing-fluorinated-gases-and-ozone-depleting-substances,301
 http://www.defra.gov.uk/environment/quality/air/fgas/enforcement,https://www.gov.uk/managing-fluorinated-gases-and-ozone-depleting-substances,301
 http://www.defra.gov.uk/environment/quality/air/fgas/fire-protection,https://www.gov.uk/managing-fluorinated-gases-and-ozone-depleting-substances,301
@@ -4620,6 +4641,7 @@ http://www.defra.gov.uk/environment/quality/chemicals/what-we-are-doing,https://
 http://www.defra.gov.uk/environment/quality/environmental-liability,,410
 http://www.defra.gov.uk/environment/quality/gm,https://www.gov.uk/government/policies/making-the-food-and-farming-industry-more-competitive-while-protecting-the-environment/supporting-pages/genetic-modification,301
 http://www.defra.gov.uk/environment/quality/gm/applications-consents,https://www.gov.uk/genetically-modified-organisms-applications-and-consents,301
+http://www.defra.gov.uk/environment/quality/industrial,http://www.defra.gov.uk/industrial-emissions/,301
 http://www.defra.gov.uk/environment/quality/industrial/eu-international/solvent-paint-directives,,410
 http://www.defra.gov.uk/environment/quality/industrial/las-regulations/charges-risk,,410
 http://www.defra.gov.uk/environment/quality/land,,410
@@ -4648,6 +4670,7 @@ http://www.defra.gov.uk/environment/quality/noise/nuisance,https://www.gov.uk/go
 http://www.defra.gov.uk/environment/quality/noise/nuisance/dust-insect-odour,https://www.gov.uk/government/policies/protecting-and-enhancing-our-urban-and-natural-environment-to-improve-public-health-and-wellbeing,301
 http://www.defra.gov.uk/environment/quality/noise/research,https://www.gov.uk/government/policies/protecting-and-enhancing-our-urban-and-natural-environment-to-improve-public-health-and-wellbeing,301
 http://www.defra.gov.uk/environment/quality/permitting,https://www.gov.uk/government/policies/protecting-and-enhancing-our-urban-and-natural-environment-to-improve-public-health-and-wellbeing,301
+http://www.defra.gov.uk/environment/quality/pollution,http://www.defra.gov.uk/industrial-emissions/,301
 http://www.defra.gov.uk/environment/quality/risk,https://www.gov.uk/government/publications/guidelines-for-environmental-risk-assessment-and-management-green-leaves-iii,301
 http://www.defra.gov.uk/environment/quality/water,,410
 http://www.defra.gov.uk/environment/quality/water/conservation,,410
@@ -4984,6 +5007,8 @@ http://www.defra.gov.uk/farming-advice/wp-includes/js/jquery/jquery-migrate.min.
 http://www.defra.gov.uk/farming-advice/wp-includes/js/jquery/jquery.js,,410
 http://www.defra.gov.uk/farming-advice/wp-includes/wlwmanifest.xml,,410
 http://www.defra.gov.uk/farming-advice/xmlrpc.php,,410
+http://www.defra.gov.uk/farminglink,http://www.defra.gov.uk/food-farm/farminglink/,301
+http://www.defra.gov.uk/farminglinkonline,http://www.defra.gov.uk/food-farm/farminglink/,301
 http://www.defra.gov.uk/fawc,,410
 http://www.defra.gov.uk/fawc/2010/12/14/news-laying-hens-101214,,410
 http://www.defra.gov.uk/fawc/2010/12/14/news-laying-hens-101214/feed,,410
@@ -5158,8 +5183,12 @@ http://www.defra.gov.uk/fawc/wp-includes/js/jquery/jquery-migrate.min.js,,410
 http://www.defra.gov.uk/fawc/wp-includes/js/jquery/jquery.js,,410
 http://www.defra.gov.uk/fawc/wp-includes/wlwmanifest.xml,,410
 http://www.defra.gov.uk/fawc/xmlrpc.php,,410
+http://www.defra.gov.uk/feed,http://www.defra.gov.uk/news/feed/,301
+http://www.defra.gov.uk/feedback.htm,http://www.defra.gov.uk/corporate/contacts/,301
+http://www.defra.gov.uk/feedback/feedback.htm,http://www.defra.gov.uk/corporate/contacts/,301
 http://www.defra.gov.uk/fera,,410
 http://www.defra.gov.uk/fera/bvdp,,410
+http://www.defra.gov.uk/fgas,http://www.defra.gov.uk/environment/quality/air/fgas/,301
 http://www.defra.gov.uk/files/banner-env-air-04.jpg,,410
 http://www.defra.gov.uk/files/fcerm-consult-infonote-sumresp.pdf,https://www.gov.uk/flood-risk-management-information-for-flood-risk-management-authorities-asset-owners-and-local-authorities,301
 http://www.defra.gov.uk/files/fcerm-consult-sumresp.pdf,https://www.gov.uk/flood-risk-management-information-for-flood-risk-management-authorities-asset-owners-and-local-authorities,301
@@ -5274,6 +5303,18 @@ http://www.defra.gov.uk/food-farm/land-manage/soil,https://www.gov.uk/avoiding-a
 http://www.defra.gov.uk/food-farm/land-manage/soil/soil-framework-directive,,410
 http://www.defra.gov.uk/food-farm/land-manage/stewardship,https://www.gov.uk/environmental-stewardship,301
 http://www.defra.gov.uk/food-farm/land-manage/uplands,https://www.gov.uk/government/publications/uplands-policy-review,301
+http://www.defra.gov.uk/foodfarm,http://www.defra.gov.uk/food-farm/,301
+http://www.defra.gov.uk/foodfarm/animaltrade,http://www.defra.gov.uk/food-farm/import-export/,301
+http://www.defra.gov.uk/foodfarm/byproducts,http://www.defra.gov.uk/food-farm/byproducts/,301
+http://www.defra.gov.uk/foodfarm/farmanimal,http://www.defra.gov.uk/food-farm/animals/,301
+http://www.defra.gov.uk/foodfarm/farmanimal/diseases,http://www.defra.gov.uk/food-farm/animals/diseases/,301
+http://www.defra.gov.uk/foodfarm/farmanimal/movements,http://www.defra.gov.uk/food-farm/animals/movements/,301
+http://www.defra.gov.uk/foodfarm/farmanimal/welfare,https://www.gov.uk/animal-welfare,301
+http://www.defra.gov.uk/foodfarm/farmmanage,http://www.defra.gov.uk/food-farm/farm-manage/,301
+http://www.defra.gov.uk/foodfarm/fisheries,http://www.defra.gov.uk/food-farm/fisheries/,301
+http://www.defra.gov.uk/foodfarm/growing,http://www.defra.gov.uk/food-farm/crops/,301
+http://www.defra.gov.uk/foodfarm/landmanage,http://www.defra.gov.uk/food-farm/land-manage/,301
+http://www.defra.gov.uk/foodfarm/policy/farminglink,http://www.defra.gov.uk/food-farm/farminglink/,301
 http://www.defra.gov.uk/forestry-panel,,410
 http://www.defra.gov.uk/forestrypanel,https://www.gov.uk/government/policy-advisory-groups/independent-panel-on-forestry,301
 http://www.defra.gov.uk/forestrypanel/2011/call-for-views-response-11080,,410
@@ -5790,6 +5831,8 @@ http://www.defra.gov.uk/habitats-review/wp-includes/js/jquery/jquery-migrate.min
 http://www.defra.gov.uk/habitats-review/wp-includes/js/jquery/jquery.js,,410
 http://www.defra.gov.uk/habitats-review/wp-includes/wlwmanifest.xml,,410
 http://www.defra.gov.uk/habitats-review/xmlrpc.php,,410
+http://www.defra.gov.uk/help.asp,http://www.defra.gov.uk/corporate/website/help/,301
+http://www.defra.gov.uk/help.htm,http://www.defra.gov.uk/corporate/website/help/,301
 http://www.defra.gov.uk/hsac,https://www.gov.uk/government/policy-advisory-groups/hazardous-substances-advisory-committee,301
 http://www.defra.gov.uk/hsac/2012/code-of-practice,https://www.gov.uk/government/policy-advisory-groups/hazardous-substances-advisory-committee,301
 http://www.defra.gov.uk/hsac/2012/code-of-practice/feed,https://www.gov.uk/government/policy-advisory-groups/hazardous-substances-advisory-committee,301
@@ -5866,6 +5909,7 @@ http://www.defra.gov.uk/hsac/wp-includes/js/jquery/jquery-migrate.min.js,,410
 http://www.defra.gov.uk/hsac/wp-includes/js/jquery/jquery.js,,410
 http://www.defra.gov.uk/hsac/wp-includes/wlwmanifest.xml,,410
 http://www.defra.gov.uk/hsac/xmlrpc.php,,410
+http://www.defra.gov.uk/index/index.htm,http://www.defra.gov.uk/corporate/website/a-z/,301
 http://www.defra.gov.uk/industrial-emissions,,410
 http://www.defra.gov.uk/industrial-emissions/2012,,410
 http://www.defra.gov.uk/industrial-emissions/2012/01,,410
@@ -7535,6 +7579,9 @@ http://www.defra.gov.uk/news/2013/04/08/appointments-to-chilterns-and-cotswolds-
 http://www.defra.gov.uk/news/2013/04/08/reappointments-forestry,https://www.gov.uk/government/news/reappointments-to-national-forestry-company,301
 http://www.defra.gov.uk/news/2013/04/09/dogs-law-changes,https://www.gov.uk/government/news/dangerous-dogs-law-changes-cover-attacks-on-private-property,301
 http://www.defra.gov.uk/news/contact,,410
+http://www.defra.gov.uk/our-responsibilities/bovine-tb,http://www.defra.gov.uk/food-farm/animals/diseases/tb/,301
+http://www.defra.gov.uk/our-responsibilities/nat-environment,http://www.defra.gov.uk/environment/natural/whitepaper/,301
+http://www.defra.gov.uk/our-responsibilities/water-white-paper,http://www.defra.gov.uk/environment/quality/water/whitepaper/,301
 http://www.defra.gov.uk/paw,https://www.gov.uk/government/policy-advisory-groups/partnership-for-action-against-wildlife-crime,301
 http://www.defra.gov.uk/paw/about,https://www.gov.uk/government/policies/protecting-animal-welfare,301
 http://www.defra.gov.uk/paw/about/feed,https://www.gov.uk/government/policies/protecting-animal-welfare,301
@@ -7761,6 +7808,7 @@ http://www.defra.gov.uk/peat-taskforce/wp-includes/js/jquery/jquery-migrate.min.
 http://www.defra.gov.uk/peat-taskforce/wp-includes/js/jquery/jquery.js,,410
 http://www.defra.gov.uk/peat-taskforce/wp-includes/wlwmanifest.xml,,410
 http://www.defra.gov.uk/peat-taskforce/xmlrpc.php,,410
+http://www.defra.gov.uk/privacy.htm,http://www.defra.gov.uk/corporate/website/privacy/,301
 http://www.defra.gov.uk/publications,https://www.gov.uk/government/publications?departments[]=department-for-environment-food-rural-affairs,301
 http://www.defra.gov.uk/publications/2011/03/15/pb11050-ragwort-disposal-guidance,https://www.gov.uk/government/publications/common-ragwort-disposal-options-guidance,301
 http://www.defra.gov.uk/publications/2011/03/15/pb12340-welfare-animals-transport,https://www.gov.uk/government/publications/welfare-of-animals-during-transport--2,301
@@ -8705,6 +8753,7 @@ http://www.defra.gov.uk/publications/files/water-for-life-market-proposals.pdf,h
 http://www.defra.gov.uk/publications/files/wildlife-countryside-act.pdf,https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/69205/wildlife-countryside-act.pdf,301
 http://www.defra.gov.uk/publications/files/workforce-monitoring2012.pdf,https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/69504/workforce-monitoring2012.pdf,301
 http://www.defra.gov.uk/publications/files/zoo-licensing-act-guide.pdf,https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/69595/zoo-licensing-act-guide.pdf,301
+http://www.defra.gov.uk/rb209,http://www.defra.gov.uk/food-farm/land-manage/nutrients/,301
 http://www.defra.gov.uk/review-ea-ne,https://www.gov.uk/government/consultations/triennial-review-of-the-environment-agency-and-natural-england,301
 http://www.defra.gov.uk/review-ea-ne/2012/120723-workshop,https://www.gov.uk/government/consultations/triennial-review-of-the-environment-agency-and-natural-england,301
 http://www.defra.gov.uk/review-ea-ne/contact,https://www.gov.uk/government/consultations/triennial-review-of-the-environment-agency-and-natural-england,301
@@ -9135,7 +9184,14 @@ http://www.defra.gov.uk/statistics/rural/what-is-rural/geographies,https://www.g
 http://www.defra.gov.uk/statistics/rural/what-is-rural/other-geographies,https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs/series/rural-urban-definition,301
 http://www.defra.gov.uk/statistics/rural/what-is-rural/rural-urban-classification,https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs/series/rural-urban-definition,301
 http://www.defra.gov.uk/statistics/rural/what-is-rural/rural-urban-definition,https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs/series/rural-urban-definition,301
+http://www.defra.gov.uk/tag,http://www.defra.gov.uk/news/tag/,301
+http://www.defra.gov.uk/terms.htm,http://www.defra.gov.uk/corporate/website/terms/,301
 http://www.defra.gov.uk/vla/science/sci_tse_stats_intro.htm,,410
+http://www.defra.gov.uk/web/accessibility.htm,http://www.defra.gov.uk/corporate/website/accessibility/,301
+http://www.defra.gov.uk/web/copyright.htm,http://www.defra.gov.uk/corporate/website/copyright/,301
+http://www.defra.gov.uk/web/help.htm,http://www.defra.gov.uk/corporate/website/help/,301
+http://www.defra.gov.uk/web/privacy.htm,http://www.defra.gov.uk/corporate/website/privacy/,301
+http://www.defra.gov.uk/web/terms.htm,http://www.defra.gov.uk/corporate/website/terms/,301
 http://www.defra.gov.uk/wildlife-pets,,410
 http://www.defra.gov.uk/wildlife-pets/circuses,https://www.gov.uk/government/policies/protecting-animal-welfare,301
 http://www.defra.gov.uk/wildlife-pets/dangerous-wild-animals,,410
@@ -9189,6 +9245,12 @@ http://www.defra.gov.uk/wildlife-pets/wildlife-management/licensing-policy,https
 http://www.defra.gov.uk/wildlife-pets/wildlife-management/policy-making-framework,,410
 http://www.defra.gov.uk/wildlife-pets/wildlife-management/rare-exploited-species,https://www.gov.uk/government/policies/protecting-biodiversity-and-ecosystems-at-home-and-abroad,301
 http://www.defra.gov.uk/wildlife-pets/wildlife-management/weeds-act-1959,https://www.gov.uk/government/policies/protecting-biodiversity-and-ecosystems-at-home-and-abroad,301
+http://www.defra.gov.uk/wildlife-pets/wildlife/management,http://www.defra.gov.uk/wildlife-pets/wildlife-management/,301
+http://www.defra.gov.uk/wildlife-pets/wildlife/management/non-native,http://www.defra.gov.uk/wildlife-pets/non-native/,301
+http://www.defra.gov.uk/wildlife-pets/wildlife/protect,http://www.defra.gov.uk/wildlife-pets/protecting-wildlife/,301
+http://www.defra.gov.uk/wildlife-pets/wildlife/protect/dwaa,http://www.defra.gov.uk/wildlife-pets/dangerous-wild-animals/,301
+http://www.defra.gov.uk/wildlife-pets/wildlife/protect/whales,http://www.defra.gov.uk/wildlife-pets/whales-dolphins/,301
+http://www.defra.gov.uk/wildlife-pets/wildlife/trade-crime,http://www.defra.gov.uk/wildlife-pets/wildlife-crime/,301
 http://www.defra.gov.uk/wildlife-pets/zoos,https://www.gov.uk/government/policies/protecting-biodiversity-and-ecosystems-at-home-and-abroad,301
 http://www.defra.gov.uk/wildlife-pets/zoos/index.htm,,410
 http://www.defra.gov.uk/wp-content/plugins/admin-bar-info/css/admin-bar.css,,410


### PR DESCRIPTION
This is the addition of all mappings from the story https://www.pivotaltracker.com/story/show/66335764.

In order to have DEFRA manage their mappings using the transition app, we must arrange to configure the GDS app with their existing server rules and existing mappings. This pull request handles the second of these.

Once this import has run, we can configure www.defra.gov.uk as a site in the transition app, and begin to devolve DEFRA mapping activity to their users.
