### PR TITLE
Remove unnecessary query strings

### DIFF
--- a/data/sites/hmrc.yml
+++ b/data/sites/hmrc.yml
@@ -9,4 +9,3 @@ furl: www.gov.uk/hmrc
 homepage: https://www.gov.uk/government/organisations/hm-revenue-customs
 aliases:
 - hmrc.gov.uk
-options: --query-string tickdpmt:dates


### PR DESCRIPTION
These were added to accommodate URLs like http://www.hmrc.gov.uk/tools/taxcredits/results.htm?tickdPmt=28&dates=24%2F12%2F2013

This particular calculator will be globally sent to a specific single URL, so the query strings are unneeded.
