### PR TITLE
Configure Queen's Harbour Master organisation on transition app

### DIFF
--- a/data/transition-sites/mod_qhm.yml
+++ b/data/transition-sites/mod_qhm.yml
@@ -1,0 +1,10 @@
+---
+site: mod_qhm
+whitehall_slug: queens-harbour-master
+title: Queen&apos;s Harbour Master
+redirection_date: 1st April 2014
+homepage: https://www.gov.uk/government/organisations/queens-harbour-master
+tna_timestamp: 20131002090906
+host: www.qhm.mod.uk
+aliases:
+- qhm.mod.uk

--- a/tld/qhm.mod.uk
+++ b/tld/qhm.mod.uk
@@ -1,0 +1,4 @@
+server {
+  server_name qhm.mod.uk;
+  rewrite ^/(.*) http://www.qhm.mod.uk/$1 permanent;
+}


### PR DESCRIPTION
Note - this will also require TLD configuration on redirector itself. The rule below is for reference only.
