### PR TITLE
Update UKVI TNA Timestamps

### DIFF
--- a/data/transition-sites/ukvi.yml
+++ b/data/transition-sites/ukvi.yml
@@ -3,7 +3,7 @@ site: ukvi
 whitehall_slug: uk-visas-and-immigration
 host: www.ukba.homeoffice.gov.uk
 redirection_date: 26th February 2014
-tna_timestamp: 20130925160031
+tna_timestamp: 20140110181512
 title: UK Visas and Immigration
 homepage: https://www.gov.uk/government/organisations/uk-visas-and-immigration
 aliases:

--- a/data/transition-sites/ukvi_lifeintheuktest.yml
+++ b/data/transition-sites/ukvi_lifeintheuktest.yml
@@ -3,7 +3,7 @@ site: ukvi_lifeintheuktest
 whitehall_slug: uk-visas-and-immigration
 host: lifeintheuktest.ukba.homeoffice.gov.uk
 redirection_date: 11th February 2014
-tna_timestamp: 20130919230248
+tna_timestamp: 20131212160954
 title: UK Visas and Immigration
 homepage: https://www.gov.uk/life-in-the-uk-test
 aliases:


### PR DESCRIPTION
This should cover some news items that were published since the current TNA timestamp in September 2013, eg: http://webarchive.nationalarchives.gov.uk/20140110182140/http://www.ukba.homeoffice.gov.uk/sitecontent/newsarticles/2014/january/08-tb-nigeria

@rjc123 are these dates partial or full crawls?
