### PR TITLE
Use the public Organisations API host (www.gov.uk)

### DIFF
--- a/lib/redirector/organisations.rb
+++ b/lib/redirector/organisations.rb
@@ -3,10 +3,10 @@ require 'gds_api/organisations'
 
 module Redirector
   class Organisations
-    WHITEHALL_PRODUCTION = 'https://whitehall-admin.production.alphagov.co.uk'
+    ORGANISATIONS_API_HOST = 'https://www.gov.uk'
 
     def organisations_api
-      @organisations_api ||= GdsApi::Organisations.new(WHITEHALL_PRODUCTION)
+      @organisations_api ||= GdsApi::Organisations.new(ORGANISATIONS_API_HOST)
     end
 
     def all

--- a/tests/lib/redirector/site_test.rb
+++ b/tests/lib/redirector/site_test.rb
@@ -12,7 +12,7 @@ class RedirectorSiteTest < MiniTest::Unit::TestCase
 
   def setup
     @old_app_domain = ORGANISATIONS_API_ENDPOINT
-    ORGANISATIONS_API_ENDPOINT.gsub!(/^.*$/, 'https://whitehall-admin.production.alphagov.co.uk')
+    ORGANISATIONS_API_ENDPOINT.gsub!(/^.*$/, 'https://www.gov.uk')
   end
 
   def teardown

--- a/tools/site_org_augmenter.rb
+++ b/tools/site_org_augmenter.rb
@@ -125,7 +125,7 @@ module Transition
       @organisations ||= begin
         return YAML.load(File.read(cached_org_path)) if File.exist?(cached_org_path)
 
-        api = GdsApi::Organisations.new('https://whitehall-admin.production.alphagov.co.uk')
+        api = GdsApi::Organisations.new('https://www.gov.uk')
 
         api.organisations.with_subsequent_pages.to_a.inject({}) do |orgs, org|
           orgs[org.title] = org


### PR DESCRIPTION
We lost the ability to connect from CI to whitehall-admin (being fixed separately), but we can happily use the public URL to access it so let's do that.
