### PR TITLE
Fix invalid host

### DIFF
--- a/data/transition-sites/mmo.yml
+++ b/data/transition-sites/mmo.yml
@@ -5,7 +5,7 @@ title: Marine Management Organisation
 redirection_date: 31st October 2014
 homepage: https://www.gov.uk/government/organisations/marine-management-organisation
 tna_timestamp: 20140108121958
-host: www.marinemanagement.org.uk/
+host: www.marinemanagement.org.uk
 furl: www.gov.uk/mmo
 aliases:
 - marinemanagement.org.uk


### PR DESCRIPTION
This was imported fine into Transition, but (possibly) caused the CDN configuration job to fail.

The invalid host will need to be manually deleted in the production database. We should probably have a host validation in the Transition app...
