### PR TITLE
Adding comments to warn against updating the tna_timestamp 

### DIFF
--- a/data/transition-sites/bis.yml
+++ b/data/transition-sites/bis.yml
@@ -3,7 +3,7 @@ site: bis
 whitehall_slug: department-for-business-innovation-skills
 host: www.bis.gov.uk
 redirection_date: 13th December 2012
-tna_timestamp: 20121212135622
+tna_timestamp: 20121212135622 # Partial: update with care - TNA will have pages from www.gov.uk
 title: Department for Business&#44; Innovation & Skills
 furl: www.gov.uk/bis
 homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills

--- a/data/transition-sites/defra.yml
+++ b/data/transition-sites/defra.yml
@@ -3,7 +3,7 @@ site: defra
 whitehall_slug: department-for-environment-food-rural-affairs
 host: www.defra.gov.uk
 redirection_date: 10th April 2013
-tna_timestamp: 20130822084033
+tna_timestamp: 20130822084033 # Partial: update with care - TNA will have pages from www.gov.uk
 title: Department for Environment&#44; Food & Rural Affairs
 furl: www.gov.uk/defra
 homepage: https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs

--- a/data/transition-sites/dfe.yml
+++ b/data/transition-sites/dfe.yml
@@ -3,7 +3,7 @@ site: dfe
 whitehall_slug: department-for-education
 host: www.education.gov.uk
 redirection_date: 23rd April 2013
-tna_timestamp: 20130123124929
+tna_timestamp: 20130123124929 # Partial: update with care - TNA will have pages from www.gov.uk
 title: Department for Education
 furl: www.gov.uk/dfe
 homepage: https://www.gov.uk/government/organisations/department-for-education

--- a/data/transition-sites/dft.yml
+++ b/data/transition-sites/dft.yml
@@ -3,7 +3,7 @@ site: dft
 whitehall_slug: department-for-transport
 host: www.dft.gov.uk
 redirection_date: 16th November 2012
-tna_timestamp: 20121107103953
+tna_timestamp: 20121107103953 # Partial: update with care - TNA will have pages from www.gov.uk
 title: Department for Transport
 furl: www.gov.uk/dft
 homepage: https://www.gov.uk/government/organisations/department-for-transport

--- a/data/transition-sites/dwp.yml
+++ b/data/transition-sites/dwp.yml
@@ -3,7 +3,7 @@ site: dwp
 whitehall_slug: department-for-work-pensions
 host: www.dwp.gov.uk
 redirection_date: 17th April 2013
-tna_timestamp: 20130128102031
+tna_timestamp: 20130128102031 # Partial: update with care - TNA will have pages from www.gov.uk
 title: Department for Work &amp; Pensions
 furl: www.gov.uk/dwp
 homepage: https://www.gov.uk/government/organisations/department-for-work-pensions

--- a/data/transition-sites/hmrc.yml
+++ b/data/transition-sites/hmrc.yml
@@ -3,7 +3,7 @@ site: hmrc
 whitehall_slug: hm-revenue-customs
 host: www.hmrc.gov.uk
 redirection_date: 28th February 2013
-tna_timestamp: 20140109143644
+tna_timestamp: 20140109143644 # Partial: update with care - TNA will have pages from www.gov.uk
 title: HM Revenue &amp; Customs
 furl: www.gov.uk/hmrc
 homepage: https://www.gov.uk/government/organisations/hm-revenue-customs

--- a/data/transition-sites/moj.yml
+++ b/data/transition-sites/moj.yml
@@ -3,7 +3,7 @@ site: moj
 whitehall_slug: ministry-of-justice
 host: www.justice.gov.uk
 redirection_date: 10th April 2013
-tna_timestamp: 20130128112038
+tna_timestamp: 20130128112038 # Partial: update with care - TNA will have pages from www.gov.uk
 title: Ministry of Justice
 furl: www.gov.uk/moj
 homepage: https://www.gov.uk/government/organisations/ministry-of-justice


### PR DESCRIPTION
These sites were part of partial transitions of corporate content; these timestamps represent the pre-transition full-site TNA crawls. If the timestamp is changed/updated, URLs for these sites may present GOV.UK pages, rather than the desired original site URL. Consider using the custom archive link feature.
