### PR TITLE
Add some extra_organisation_slugs for BIS

### DIFF
--- a/data/transition-sites/bis.yml
+++ b/data/transition-sites/bis.yml
@@ -10,3 +10,6 @@ homepage: https://www.gov.uk/government/organisations/department-for-business-in
 css: department-for-business-innovation-skills
 aliases:
 - www.berr.gov.uk
+extra_organisation_slugs:
+- government-office-for-science
+- british-hallmarking-council


### PR DESCRIPTION
- Now https://github.com/alphagov/transition/pull/245 is merged, give
  people an example of how to add extra organisation slugs. These are
  real BIS organisations - GO Science and British Hallmarking Council.
