### PR TITLE
[UKVI] Add remaining hosts

### DIFF
--- a/data/transition-sites/ukvi.yml
+++ b/data/transition-sites/ukvi.yml
@@ -9,8 +9,10 @@ homepage: https://www.gov.uk/government/organisations/uk-visas-and-immigration
 aliases:
 - bia.homeoffice.gov.uk
 - biapreview.homeoffice.gov.uk
+- contact-ukba.homeoffice.gov.uk
 - ind.homeoffice.gov.uk
 - origin.ukba.homeoffice.gov.uk # Currently used for us to serve proxied content. Will move eventually.
+- report-ukba.homeoffice.gov.uk
 - ukba.homeoffice.gov.uk
 - www.bia.homeoffice.gov.uk
 - www.biapreview.homeoffice.gov.uk


### PR DESCRIPTION
These have been used to serve up a contact form and a form to check an individual's right to work. They are aliases of the main site, but existed to have the forms available over SSL. Development is nearly complete on their replacements, so we are getting ready to redirect them.
