### PR TITLE
Update UKTI TNA timestamp to latest full crawl

### DIFF
--- a/data/transition-sites/ukti.yml
+++ b/data/transition-sites/ukti.yml
@@ -4,7 +4,7 @@ whitehall_slug: uk-trade-investment
 title: UK Trade &amp; Investment
 redirection_date: 14th April 2014
 homepage: https://www.gov.uk/government/organisations/uk-trade-investment
-tna_timestamp: 20140403154217 # Later timestamps are unsuitable, pending TNA recrawl
+tna_timestamp: 20140403154217
 host: www.ukti.gov.uk
 furl: www.gov.uk/ukti
 aliases:


### PR DESCRIPTION
UKTI have commissioned this crawl, and have confirmed its validity.  
They want us to use this as the default.
