### PR TITLE
Add some DfT sub-organisations that can edit the DfT mappings

### DIFF
--- a/data/transition-sites/dft.yml
+++ b/data/transition-sites/dft.yml
@@ -17,3 +17,4 @@ extra_organisation_slugs:
 - vehicle-and-operator-services-agency
 - disabled-persons-transport-advisory-committee
 - driving-standards-agency
+- driver-and-vehicle-standards-agency


### PR DESCRIPTION
- This adds extra_organisation_slugs to DfT so that those orgs can
  start using the transition tool from day one when is deployed. This
  list has been confirmed with DfT to be the only orgs they want
  editing their site's mappings (i.e. these orgs have sites inside
  dft.gov.uk).
