### PR TITLE
Fix script to generate tld config

### DIFF
--- a/tools/new_tld_rewrite.sh
+++ b/tools/new_tld_rewrite.sh
@@ -4,6 +4,6 @@ rootdomain=$1
 
 touch tld/$rootdomain
 echo 'server {' >> tld/$rootdomain
-echo '  server_name '$rootdomain >> tld/$rootdomain
+echo '  server_name '$rootdomain';' >> tld/$rootdomain
 echo '  rewrite ^/(.*) http://www.'$rootdomain'/$1 permanent;' >> tld/$rootdomain
 echo '}' >> tld/$rootdomain


### PR DESCRIPTION
The semi-colon after the server_name is required for the config to
be valid.
