### PR TITLE
[BIS] Add previously merged BIS sites

### DIFF
--- a/data/transition-sites/bis_bnsc.yml
+++ b/data/transition-sites/bis_bnsc.yml
@@ -1,0 +1,10 @@
+---
+site: bis_bnsc
+whitehall_slug: uk-space-agency
+title: UK Space Agency
+redirection_date:
+homepage: https://www.gov.uk/government/organisations/uk-space-agency
+tna_timestamp: 20100303152438
+host: www.bnsc.gov.uk
+global: =301 https://www.gov.uk/government/organisations/uk-space-agency
+

--- a/data/transition-sites/bis_cst.yml
+++ b/data/transition-sites/bis_cst.yml
@@ -1,0 +1,12 @@
+---
+site: bis_cst
+whitehall_slug: council-for-science-and-technology
+title: Council for Science and Technology
+redirection_date:
+homepage: https://www.gov.uk/government/organisations/council-for-science-and-technology
+furl: www.gov.uk/cst
+tna_timestamp: 20100714131339
+host: www.cst.gov.uk
+aliases:
+- www2.cst.gov.uk
+global: =301 https://www.gov.uk/government/organisations/council-for-science-and-technology

--- a/data/transition-sites/bis_foresight.yml
+++ b/data/transition-sites/bis_foresight.yml
@@ -1,0 +1,10 @@
+---
+site: bis_foresight
+whitehall_slug: government-office-for-science
+title: Government Office for Science
+redirection_date:
+homepage: https://www.gov.uk/government/organisations/government-office-for-science
+furl: www.gov.uk/go-science
+tna_timestamp: 20130502130215
+host: www.foresight.gov.uk
+global: =301 https://www.gov.uk/government/organisations/government-office-for-science

--- a/data/transition-sites/bis_nmo.yml
+++ b/data/transition-sites/bis_nmo.yml
@@ -1,0 +1,10 @@
+---
+site: bis_nmo
+whitehall_slug: national-measurement-office
+title: National Measurement Office
+redirection_date:
+homepage: https://www.gov.uk/government/organisations/national-measurement-office
+furl: www.gov.uk/nmo
+tna_timestamp: 20110213145434
+host: www.nmo.bis.gov.uk
+global: =301 https://www.gov.uk/government/organisations/national-measurement-office

--- a/data/transition-sites/bis_nwml.yml
+++ b/data/transition-sites/bis_nwml.yml
@@ -1,0 +1,10 @@
+---
+site: bis_nwml
+whitehall_slug: national-measurement-office
+title: National Measurement Office
+redirection_date:
+homepage: https://www.gov.uk/government/organisations/national-measurement-office
+furl: www.gov.uk/nmo
+tna_timestamp: 20090218070806
+host: www.nwml.gov.uk
+global: =301 https://www.gov.uk/government/organisations/national-measurement-office

--- a/data/transition-sites/bis_rohs.yml
+++ b/data/transition-sites/bis_rohs.yml
@@ -1,0 +1,11 @@
+---
+site: bis_rohs
+whitehall_slug: national-measurement-office
+title: National Measurement Office
+redirection_date:
+homepage: https://www.gov.uk/government/organisations/national-measurement-office
+furl: www.gov.uk/nmo
+tna_timestamp: 20110206081048
+host: www.rohs.gov.uk
+global: =301 https://www.gov.uk/government/organisations/national-measurement-office
+

--- a/data/transition-sites/bis_shareholder_executive.yml
+++ b/data/transition-sites/bis_shareholder_executive.yml
@@ -1,0 +1,9 @@
+---
+site: bis_shareholder_executive
+whitehall_slug: the-shareholder-executive
+title: The Shareholder Executive
+redirection_date: 31st October 2014
+homepage: https://www.gov.uk/government/organisations/the-shareholder-executive
+tna_timestamp: 20100520100326
+host: www.shareholderexecutive.gov.uk
+global: =301 https://www.gov.uk/government/organisations/the-shareholder-executive

--- a/data/transition-sites/bis_space_agency.yml
+++ b/data/transition-sites/bis_space_agency.yml
@@ -1,0 +1,11 @@
+---
+site: bis_space_agency
+whitehall_slug: uk-space-agency
+title: UK Space Agency
+redirection_date:
+homepage: https://www.gov.uk/government/organisations/uk-space-agency
+tna_timestamp: 20120305143602
+host: www.ukspaceagency.bis.gov.uk
+aliases:
+- ukspaceagency.bis.gov.uk
+global: =301 https://www.gov.uk/government/organisations/uk-space-agency


### PR DESCRIPTION
These sites were previously merged into www.bis.gov.uk. They currently redirect
to www.bis.gov.uk/sub_org, appending whatever path was supplied. If bouncer
supported that behaviour, we'd set that up.

Timestamps were chosen as the last archive before they were redirected to a
path on www.bis.gov.uk. This may not be optimal...

These were all found in the BIS logs.
