### PR TITLE
Add missing query params for Monitor and UKCES

### DIFF
--- a/data/transition-sites/monitor.yml
+++ b/data/transition-sites/monitor.yml
@@ -13,3 +13,5 @@ aliases:
 - monitor-nhsft.org.uk
 - www.monitor-nhsft.gov.uk
 - www.monitor-nhsft.org.uk
+# Used for file downloads
+options: --query-string code

--- a/data/transition-sites/ukces.yml
+++ b/data/transition-sites/ukces.yml
@@ -7,3 +7,5 @@ homepage: https://www.gov.uk/government/organisations/uk-commission-for-employme
 tna_timestamp: 20140108090250
 host: www.ukces.org.uk
 furl: www.gov.uk/ukces
+# page is a document ID
+options: --query-string page


### PR DESCRIPTION
Discovered these after looking at the Web Archive's URLs for these domains.
