### PR TITLE
Add querystrings to support past MCA news releases

### DIFF
--- a/data/transition-sites/dft.yml
+++ b/data/transition-sites/dft.yml
@@ -7,7 +7,7 @@ tna_timestamp: 20121107103953 # Partial: update with care - TNA will have pages 
 title: Department for Transport
 furl: www.gov.uk/dft
 homepage: https://www.gov.uk/government/organisations/department-for-transport
-options: --query-string agency
+options: --query-string agency:id:m:y
 aliases:
 - dft.gov.uk
 css: department-for-transport


### PR DESCRIPTION
http://www.dft.gov.uk/mca/mcga07-home/newsandpublications/press-releases.htm?id=ECB0F32816AD28B3&m=7&y=2013 needs a query string, so we can serve an effective 410 page
