### PR TITLE
[UKTI] Split Milan campaign site from campaigns

### DIFF
--- a/data/transition-sites/ukti_campaigns.yml
+++ b/data/transition-sites/ukti_campaigns.yml
@@ -94,7 +94,6 @@ aliases:
 - www.ukauto.ukti.gov.uk
 - www.ukbrazilhealthweek.ukti.gov.uk
 - www.ukisrael2012.ukti.gov.uk
-- www.ukmilan2015.ukti.gov.uk
 - www.ukpakistanannualflagshipconference.ukti.gov.uk
 - www.ukpakistanregionalconference.ukti.gov.uk
 - www.ukpavilion2015.ukti.gov.uk

--- a/data/transition-sites/ukti_milan2015.yml
+++ b/data/transition-sites/ukti_milan2015.yml
@@ -1,0 +1,9 @@
+---
+site: ukti_milan2015
+whitehall_slug: uk-trade-investment
+title: UK Trade &amp; Investment
+redirection_date: 14th April 2014
+homepage: https://www.gov.uk/government/organisations/uk-trade-investment
+tna_timestamp: 20150101010101
+host: www.ukmilan2015.ukti.gov.uk
+global: =301 https://www.gov.uk/government/topical-events/the-uk-pavilion-at-milan-expo-2015


### PR DESCRIPTION
They want this to redirect to the specific page, rather than the GOV.UK UKTI
homepage. It will need manual work to reassign the host to the new site in the
database.
