### PR TITLE
[UKTI] Remove contactus.ukti.gov.uk

### DIFF
--- a/data/transition-sites/ukti_campaigns.yml
+++ b/data/transition-sites/ukti_campaigns.yml
@@ -8,7 +8,6 @@ tna_timestamp: 20150101010101
 host: www.ukadvisorynetwork.co.uk
 furl: www.gov.uk/ukti
 aliases:
-- contactus.ukti.gov.uk
 - france.ukti.gov.uk
 - germany.ukti.gov.uk
 - iberia.ukti.gov.uk


### PR DESCRIPTION
This domain was created to provide a contact form for UKTI post-transition and
isn't transitioning.

This will need to be manually deleted.
