### PR TITLE
Add Civil Service sites to transition app

### DIFF
--- a/data/transition-sites/civilservice.yml
+++ b/data/transition-sites/civilservice.yml
@@ -8,3 +8,4 @@ tna_timestamp: 20140128030838
 host: www.civilservice.gov.uk
 aliases:
 - civilservice.gov.uk
+options: --query-string p

--- a/data/transition-sites/civilservice_portal.yml
+++ b/data/transition-sites/civilservice_portal.yml
@@ -6,3 +6,4 @@ redirection_date: 1st May 2014
 homepage: https://www.gov.uk/government/organisations/civil-service
 tna_timestamp: 20131003151638
 host: my.civilservice.gov.uk
+options: --query-string p


### PR DESCRIPTION
Standard set-up of a site on the transition app.

Note the query strings are used in URLs of the form http://www.civilservice.gov.uk/?p=473 , which have pre-existing 301s to more user-friendly URLS
