### PR TITLE
Initial configuration for customs.hmrc.gov.uk

### DIFF
--- a/data/transition-sites/hmrc_customs.yml
+++ b/data/transition-sites/hmrc_customs.yml
@@ -1,0 +1,10 @@
+---
+site: hmrc_customs
+whitehall_slug: hm-revenue-customs
+title: HM Revenue &amp; Customs
+redirection_date: 1st June 2014
+homepage: https://www.gov.uk/government/organisations/hm-revenue-customs
+tna_timestamp: 20140304175147
+host: customs.hmrc.gov.uk
+furl: www.gov.uk/hmrc
+options: --query-string _nfpb:_pageLabel:propertyType:columns:id


### PR DESCRIPTION
This configuration is to accommodate vat notices to be scraped and imported, with document source of [this form](http://customs.hmrc.gov.uk/channelsPortalWebApp/channelsPortalWebApp.portal?_nfpb=true&_pageLabel=pageLibrary_PublicNoticesAndInfoSheets&propertyType=document&columns=1&id=HMCE_CL_000080)

There may be the need to add additional query strings params at a later point.
