### PR TITLE
[Sitemap] Don't truncate URLs containing ( or )

### DIFF
--- a/tools/sitemap.sh
+++ b/tools/sitemap.sh
@@ -14,7 +14,7 @@ if [ $subdir ]
 		echo "Spidering a whole domain $domain"
 		wget --no-parent -r -l0 -x -k --reject=pdf --reject=PDF --reject=jpg --reject=JPG --reject=gif --reject=GIF -t2 -nd -P $domain -e robots=off -o $domain.log $target
 	  cat $domain/*htm* >> $domain.log
-	  grep -F $domain $domain.log | grep -o 'http:\/\/[^\ \"\(\)\<\>]*' | sed 's/\/$//' | sort | uniq > $domain.urls.txt
+	  grep -F $domain $domain.log | grep -o 'http:\/\/[^\ \"\<\>]*' | sed 's/\/$//' | sort | uniq > $domain.urls.txt
 
 fi
 


### PR DESCRIPTION
I'm not sure why it was doing this and @rjc123 is on holiday for a few weeks. It was generating truncated URLs on www.cac.gov.uk, eg:
http://www.cac.gov.uk/media/word/1/i/I___C_Application_Form_
rather than:
http://www.cac.gov.uk/media/word/1/i/I___C_Application_Form_(Reg_10(1)).doc
