### PR TITLE
[*AIB] Add missing "file" query param

### DIFF
--- a/data/transition-sites/aaib.yml
+++ b/data/transition-sites/aaib.yml
@@ -9,3 +9,4 @@ host: www.aaib.gov.uk
 furl: www.gov.uk/aaib
 aliases:
 - aaib.gov.uk
+options: --query-string file

--- a/data/transition-sites/maib.yml
+++ b/data/transition-sites/maib.yml
@@ -9,3 +9,4 @@ host: www.maib.gov.uk
 furl: www.gov.uk/maib
 aliases:
 - maib.gov.uk
+options: --query-string file

--- a/data/transition-sites/raib.yml
+++ b/data/transition-sites/raib.yml
@@ -9,3 +9,4 @@ host: www.raib.gov.uk
 furl: www.gov.uk/raib
 aliases:
 - raib.gov.uk
+options: --query-string file


### PR DESCRIPTION
This is used in URLs like:
http://www.aaib.gov.uk/cms_resources.cfm?file=/AAIB%20Bulletin%205-2014.pdf
