### PR TITLE
Delete tests for aka.bis.gov.uk

### DIFF
--- a/data/tests/aka.bis.gov.uk.csv
+++ b/data/tests/aka.bis.gov.uk.csv
@@ -1,5 +1,0 @@
-Old Url,New Url,Status
-http://aka.bis.gov.uk/,https://www.gov.uk/government/organisations/department-for-business-innovation-skills,301
-http://aka.bis.gov.uk/britishhallmarkingcouncil,https://www.gov.uk/government/organisations/british-hallmarking-council,301
-http://aka.bis.gov.uk/cicregulator/,https://www.gov.uk/government/organisations/office-of-the-regulator-of-community-interest-companies,301
-http://aka.bis.gov.uk/cst,https://www.gov.uk/government/organisations/council-for-science-and-technology,301


### PR DESCRIPTION
bis has been managed by transition for some time, and now that it
has fully transitioned we shouldn't need to test the aka domain anyway.
