### PR TITLE
Add GDS as organisation to all directgov and businesslink sites

### DIFF
--- a/data/sites/businesslink.yml
+++ b/data/sites/businesslink.yml
@@ -20,3 +20,5 @@ aliases:
 - msn.businesslink.gov.uk
 - sagestartup.businesslink.gov.uk
 - simplybusiness.businesslink.gov.uk
+extra_organisation_slugs:
+- government-digital-service

--- a/data/sites/businesslink_lrc.yml
+++ b/data/sites/businesslink_lrc.yml
@@ -10,3 +10,5 @@ homepage: https://www.gov.uk/browse/business
 global: =410
 css: businesslink
 options: --query-string xgovr3h
+extra_organisation_slugs:
+- government-digital-service

--- a/data/sites/businesslink_ukwelcomes.yml
+++ b/data/sites/businesslink_ukwelcomes.yml
@@ -12,3 +12,5 @@ aliases:
 - upload.ukwelcomes.businesslink.gov.uk
 - online.ukwelcomes.businesslink.gov.uk
 - ukwelcomes.businesslink.gov.uk
+extra_organisation_slugs:
+- government-digital-service

--- a/data/sites/directgov.yml
+++ b/data/sites/directgov.yml
@@ -20,3 +20,5 @@ locations:
   operation: ^~
   status: 301
   new_url: https://www.gov.uk/search
+extra_organisation_slugs:
+- government-digital-service

--- a/data/sites/directgov_campaigns.yml
+++ b/data/sites/directgov_campaigns.yml
@@ -15,3 +15,5 @@ locations:
   operation: ^~
   status: 301
   new_url: https://www.gov.uk/firekills
+extra_organisation_slugs:
+- government-digital-service

--- a/data/sites/directgov_subdomains.yml
+++ b/data/sites/directgov_subdomains.yml
@@ -133,3 +133,5 @@ aliases:
 - www.yourfuture.direct.gov.uk
 - yourfuture.direct.gov.uk
 - yp.direct.gov.uk
+extra_organisation_slugs:
+- government-digital-service

--- a/data/transition-sites/businesslink_budget.yml
+++ b/data/transition-sites/businesslink_budget.yml
@@ -7,3 +7,5 @@ title: Business Link
 furl: www.gov.uk
 homepage: https://www.gov.uk/government/topics/public-spending
 css: businesslink
+extra_organisation_slugs:
+- government-digital-service

--- a/data/transition-sites/businesslink_elearning.yml
+++ b/data/transition-sites/businesslink_elearning.yml
@@ -10,3 +10,5 @@ global: =301 https://www.gov.uk/browse/business
 css: businesslink
 aliases:
 - www.elearning.businesslink.gov.uk
+extra_organisation_slugs:
+- government-digital-service

--- a/data/transition-sites/businesslink_events.yml
+++ b/data/transition-sites/businesslink_events.yml
@@ -10,3 +10,5 @@ global: =301 https://www.gov.uk/business-training-and-networking-events-near-you
 css: businesslink
 aliases:
 - www.events.businesslink.gov.uk
+extra_organisation_slugs:
+- government-digital-service

--- a/data/transition-sites/businesslink_events_admin.yml
+++ b/data/transition-sites/businesslink_events_admin.yml
@@ -8,3 +8,5 @@ furl: www.gov.uk
 homepage: https://admin.business-events.org.uk
 global: =301 https://admin.business-events.org.uk
 css: businesslink
+extra_organisation_slugs:
+- government-digital-service

--- a/data/transition-sites/businesslink_hmrc.yml
+++ b/data/transition-sites/businesslink_hmrc.yml
@@ -7,3 +7,5 @@ title: Business Link
 furl: www.gov.uk
 homepage: https://www.gov.uk/government/topics/public-spending
 css: businesslink
+extra_organisation_slugs:
+- government-digital-service

--- a/data/transition-sites/businesslink_improve.yml
+++ b/data/transition-sites/businesslink_improve.yml
@@ -10,3 +10,5 @@ global: =301 https://www.gov.uk/growing-your-business
 css: businesslink
 aliases:
 - www.improve.businesslink.gov.uk
+extra_organisation_slugs:
+- government-digital-service

--- a/data/transition-sites/businesslink_info.yml
+++ b/data/transition-sites/businesslink_info.yml
@@ -7,3 +7,5 @@ title: Business Link
 furl: www.gov.uk
 homepage: https://www.gov.uk
 css: businesslink
+extra_organisation_slugs:
+- government-digital-service

--- a/data/transition-sites/businesslink_tariff.yml
+++ b/data/transition-sites/businesslink_tariff.yml
@@ -11,3 +11,5 @@ css: businesslink
 aliases:
 - www.tariff.businesslink.gov.uk
 - content.tariff.businesslink.gov.uk
+extra_organisation_slugs:
+- government-digital-service

--- a/data/transition-sites/businesslink_www2.yml
+++ b/data/transition-sites/businesslink_www2.yml
@@ -7,3 +7,5 @@ title: Business Link
 furl: www.gov.uk
 homepage: https://www.gov.uk
 css: businesslink
+extra_organisation_slugs:
+- government-digital-service

--- a/data/transition-sites/directgov_innovate.yml
+++ b/data/transition-sites/directgov_innovate.yml
@@ -7,3 +7,5 @@ homepage: https://www.gov.uk/government/policy-teams/government-digital-service
 tna_timestamp: 20121017175053
 host: innovate.direct.gov.uk
 global: =410
+extra_organisation_slugs:
+- government-digital-service

--- a/data/transition-sites/directgov_jobseekers.yml
+++ b/data/transition-sites/directgov_jobseekers.yml
@@ -1,6 +1,6 @@
 ---
 site: directgov_jobseekers
-whitehall_slug: government-digital-service
+whitehall_slug: department-for-work-pensions
 host: jobseekers.direct.gov.uk
 redirection_date: 17th October 2012
 tna_timestamp: 20121015000000
@@ -12,3 +12,5 @@ aliases:
 - www.jobseekers.direct.gov.uk
 - jobseeker.direct.gov.uk
 css: directgov
+extra_organisation_slugs:
+- government-digital-service

--- a/data/transition-sites/directgov_terror.yml
+++ b/data/transition-sites/directgov_terror.yml
@@ -8,3 +8,5 @@ tna_timestamp: 20121017175053
 host: reporting.direct.gov.uk
 furl: www.gov.uk/report-terrorism
 global: =301 https://www.gov.uk/report-terrorism
+extra_organisation_slugs:
+- government-digital-service


### PR DESCRIPTION
Note the change of ownership of jobseekers.direct.gov.uk from GDS to DWP
