### PR TITLE
Configure nationalcollege.org.uk on the transition tool

### DIFF
--- a/data/transition-sites/nctl.yml
+++ b/data/transition-sites/nctl.yml
@@ -1,0 +1,13 @@
+---
+site: nctl
+whitehall_slug: national-college-for-teaching-and-leadership
+title: National College for Teaching and Leadership
+redirection_date: 1st September 2014
+homepage: https://www.gov.uk/government/organisations/national-college-for-teaching-and-leadership
+tna_timestamp: 20140320171022
+host: www.nationalcollege.org.uk
+furl: www.gov.uk/nctl
+aliases:
+- nationalcollege.org.uk
+# options: --query-string qstring1:qstring2:qstring3
+# No query string analysis yet


### PR DESCRIPTION
This site is a training and leadership platform for the National College of Teaching and Leadership. In September 2014, they will be decommissioning the existing host for this site and turning off the old site. In its place, they will be launching a newly designed and developed replacement into the same domain.

From the perspective of the transition tool, this means nationalcollege.org.uk is a curious partial transition, where likely traffic patterns will be:
- user visits old path on nationalcollege.org.uk
- user journey is redirected to partial domain (possibly AKA, or old.nationalcollege.org.uk, tbd)
- user is mapped using our tool to either 410 - webarchive, or 301 to appropriate replacement content, 
- if 301, user will then be sent on to www.nationalcollege.org.uk/new/path
