### PR TITLE
[UKTI] Move Sirius campaign to a dedicated site

### DIFF
--- a/data/transition-sites/ukti_campaigns.yml
+++ b/data/transition-sites/ukti_campaigns.yml
@@ -80,7 +80,6 @@ aliases:
 - www.parisairshow.ukti.gov.uk
 - www.purelondon.ukti.gov.uk
 - www.renewableuk.ukti.gov.uk
-- www.siriusprogramme.ukti.gov.uk
 - www.spielwarenmesse.ukti.gov.uk
 - www.sportsprojects.uktradeinvest.gov.uk
 - www.subsaharanshowcase.ukti.gov.uk

--- a/data/transition-sites/ukti_sirius.yml
+++ b/data/transition-sites/ukti_sirius.yml
@@ -1,0 +1,10 @@
+---
+site: ukti_sirius
+whitehall_slug: uk-trade-investment
+title: UK Trade &amp; Investment
+redirection_date: 14th April 2014
+homepage: https://www.gov.uk/government/organisations/uk-trade-investment
+tna_timestamp: 20150101010101
+host: www.siriusprogramme.ukti.gov.uk
+furl: www.gov.uk/ukti
+global: =301 https://www.gov.uk/the-sirius-programme


### PR DESCRIPTION
They want it to redirect to a different place.

Transition can handle this now that https://github.com/alphagov/transition/pull/328 has been deployed.
