### PR TITLE
Remove duplicate org-site relationship for directgov_drugdrive

### DIFF
--- a/data/transition-sites/directgov_drugdrive.yml
+++ b/data/transition-sites/directgov_drugdrive.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20130604185830
 host: drugdrive.direct.gov.uk
 global: =301 http://think.direct.gov.uk/drug-driving.html
 css: directgov
-extra_organisation_slugs:
-- government-digital-service


### PR DESCRIPTION
Having GDS as the owning org via whitehall_slug and also in
extra_organisations was making the site show up twice on the GDS
org page in Transition.
