### PR TITLE
Remove duplicate extra_organisations

### DIFF
--- a/data/sites/businesslink_lrc.yml
+++ b/data/sites/businesslink_lrc.yml
@@ -10,5 +10,3 @@ homepage: https://www.gov.uk/browse/business
 global: =410
 css: businesslink
 options: --query-string xgovr3h
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_actonco2.yml
+++ b/data/transition-sites/directgov_actonco2.yml
@@ -11,5 +11,3 @@ homepage: https://www.gov.uk
 title: Directgov
 aliases:
 - www.actonco2.direct.gov.uk
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_agencyworkers.yml
+++ b/data/transition-sites/directgov_agencyworkers.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_backtowork.yml
+++ b/data/transition-sites/directgov_backtowork.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_benefits-adviser.yml
+++ b/data/transition-sites/directgov_benefits-adviser.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20120628213336
 host: benefits-adviser.direct.gov.uk
 global: =301 https://www.gov.uk/benefits-adviser
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_beplantwise.yml
+++ b/data/transition-sites/directgov_beplantwise.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20120905095558
 host: beplantwise.direct.gov.uk
 global: =301 https://secure.fera.defra.gov.uk/nonnativespecies/beplantwise
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_betterfuture.yml
+++ b/data/transition-sites/directgov_betterfuture.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20120905095556
 host: betterfuture.direct.gov.uk
 global: =301 https://www.gov.uk/browse/working/workplace-personal-pensions
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_bursarymap.yml
+++ b/data/transition-sites/directgov_bursarymap.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_buyerbeware.yml
+++ b/data/transition-sites/directgov_buyerbeware.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_careandsupport.yml
+++ b/data/transition-sites/directgov_careandsupport.yml
@@ -11,5 +11,3 @@ homepage: https://www.gov.uk
 title: Directgov
 aliases:
 - www.careandsupport.direct.gov.uk
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_careersadvice-findacourse.yml
+++ b/data/transition-sites/directgov_careersadvice-findacourse.yml
@@ -12,5 +12,3 @@ title: Directgov
 aliases:
 - careersadvice-findacourse.direct.gov.uk
 - careersadvice-findacourse2.direct.gov.uk
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_careersadvice.yml
+++ b/data/transition-sites/directgov_careersadvice.yml
@@ -11,5 +11,3 @@ homepage: https://www.gov.uk
 title: Directgov
 aliases:
 - www.careersadvice.direct.gov.uk
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_childsafety.yml
+++ b/data/transition-sites/directgov_childsafety.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_chwiliadgwaith.yml
+++ b/data/transition-sites/directgov_chwiliadgwaith.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_clickcleverclicksafe.yml
+++ b/data/transition-sites/directgov_clickcleverclicksafe.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_communitypayback.yml
+++ b/data/transition-sites/directgov_communitypayback.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_consultations.yml
+++ b/data/transition-sites/directgov_consultations.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20130103042447
 host: consultations.direct.gov.uk
 global: =301 https://www.gov.uk/government/consultations
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_countdowntouni.yml
+++ b/data/transition-sites/directgov_countdowntouni.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_dev-moneytolearn.yml
+++ b/data/transition-sites/directgov_dev-moneytolearn.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_dotgovlabs.yml
+++ b/data/transition-sites/directgov_dotgovlabs.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_drivercpc.yml
+++ b/data/transition-sites/directgov_drivercpc.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20130502091130
 host: drivercpc.direct.gov.uk
 global: =301 https://www.gov.uk/driver-certificate-of-professional-competence-cpc
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_drugdrive.yml
+++ b/data/transition-sites/directgov_drugdrive.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20130604185830
 host: drugdrive.direct.gov.uk
 global: =301 http://think.direct.gov.uk/drug-driving.html
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_ecotownsyoursay.yml
+++ b/data/transition-sites/directgov_ecotownsyoursay.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_ema.yml
+++ b/data/transition-sites/directgov_ema.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_epc.yml
+++ b/data/transition-sites/directgov_epc.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20121007083059
 host: epc.direct.gov.uk
 global: =301 https://www.gov.uk/buy-sell-your-home/energy-performance-certificates
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_extraordinary.yml
+++ b/data/transition-sites/directgov_extraordinary.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_familyservices.yml
+++ b/data/transition-sites/directgov_familyservices.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_firekills.yml
+++ b/data/transition-sites/directgov_firekills.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20121106112314
 host: firekills.direct.gov.uk
 global: =301 https://www.gov.uk/firekills
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_firstjob.yml
+++ b/data/transition-sites/directgov_firstjob.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_foodimports.yml
+++ b/data/transition-sites/directgov_foodimports.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_fulloflife.yml
+++ b/data/transition-sites/directgov_fulloflife.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20110804183256
 host: fulloflife.direct.gov.uk
 global: =301 http://campaigns.dwp.gov.uk/campaigns/olderpeoplesday
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_geton.yml
+++ b/data/transition-sites/directgov_geton.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_go.yml
+++ b/data/transition-sites/directgov_go.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_gotouni.yml
+++ b/data/transition-sites/directgov_gotouni.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_homebuying.yml
+++ b/data/transition-sites/directgov_homebuying.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_homeselling.yml
+++ b/data/transition-sites/directgov_homeselling.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_keepwarmkeepwell.yml
+++ b/data/transition-sites/directgov_keepwarmkeepwell.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_kids.yml
+++ b/data/transition-sites/directgov_kids.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_legacy.yml
+++ b/data/transition-sites/directgov_legacy.yml
@@ -50,5 +50,3 @@ aliases:
 - video.direct.gov.uk
 - win.nextstep.direct.gov.uk
 - www.studyfirst.direct.gov.uk
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_letskeepcrimedown.yml
+++ b/data/transition-sites/directgov_letskeepcrimedown.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_localcrime.yml
+++ b/data/transition-sites/directgov_localcrime.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_mortgagehelp.yml
+++ b/data/transition-sites/directgov_mortgagehelp.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_muckin4life.yml
+++ b/data/transition-sites/directgov_muckin4life.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_mycouncil.yml
+++ b/data/transition-sites/directgov_mycouncil.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20130221165347
 host: mycouncil.direct.gov.uk
 global: =301 https://www.gov.uk/find-your-local-council
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_nagoya.yml
+++ b/data/transition-sites/directgov_nagoya.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_nationalcitizenservice.yml
+++ b/data/transition-sites/directgov_nationalcitizenservice.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20140108014610
 host: nationalcitizenservice.direct.gov.uk
 global: =301 http://www.ncsyes.co.uk
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_nextstep.yml
+++ b/data/transition-sites/directgov_nextstep.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_nmw.yml
+++ b/data/transition-sites/directgov_nmw.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20111030100705
 host: nmw.direct.gov.uk
 global: =301 https://www.gov.uk/your-right-to-minimum-wage
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_nuclearpower2007.yml
+++ b/data/transition-sites/directgov_nuclearpower2007.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_oneplace.yml
+++ b/data/transition-sites/directgov_oneplace.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_pandemicflu.yml
+++ b/data/transition-sites/directgov_pandemicflu.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_payandworkrightscampaign.yml
+++ b/data/transition-sites/directgov_payandworkrightscampaign.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_policingpledge.yml
+++ b/data/transition-sites/directgov_policingpledge.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_relationshipsupport.yml
+++ b/data/transition-sites/directgov_relationshipsupport.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_renewyourtaxcredits.yml
+++ b/data/transition-sites/directgov_renewyourtaxcredits.yml
@@ -8,5 +8,3 @@ tna_timestamp: 2020101010101010 # Plug for missing timestamp
 host: renewyourtaxcredits.direct.gov.uk
 global: =301 https://www.gov.uk/browse/benefits/tax-credits
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_saferstreets.yml
+++ b/data/transition-sites/directgov_saferstreets.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_sciencesowhat.yml
+++ b/data/transition-sites/directgov_sciencesowhat.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_smallsteps4life.yml
+++ b/data/transition-sites/directgov_smallsteps4life.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_spotteenabuse.yml
+++ b/data/transition-sites/directgov_spotteenabuse.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_stoploansharks.yml
+++ b/data/transition-sites/directgov_stoploansharks.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_stoppovertynow.yml
+++ b/data/transition-sites/directgov_stoppovertynow.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_studentfinance.yml
+++ b/data/transition-sites/directgov_studentfinance.yml
@@ -11,5 +11,3 @@ homepage: https://www.gov.uk
 title: Directgov
 aliases:
 - www.studentfinance-yourfuture.direct.gov.uk
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_studenttaxadvice.yml
+++ b/data/transition-sites/directgov_studenttaxadvice.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_taxcredits.yml
+++ b/data/transition-sites/directgov_taxcredits.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20081106070407
 host: taxcredits.direct.gov.uk
 global: =301 https://www.gov.uk/browse/benefits/tax-credits
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_taxcreditsvideos.yml
+++ b/data/transition-sites/directgov_taxcreditsvideos.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20120905094420
 host: taxcreditsvideos.direct.gov.uk
 global: =301 https://www.gov.uk/browse/benefits/tax-credits
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_thebigtreeplant.yml
+++ b/data/transition-sites/directgov_thebigtreeplant.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_thinkbike.yml
+++ b/data/transition-sites/directgov_thinkbike.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20111030104156
 host: thinkbike.direct.gov.uk
 global: =301 http://think.direct.gov.uk/motorcycles.html
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_thinkdrinkdrive.yml
+++ b/data/transition-sites/directgov_thinkdrinkdrive.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20120905095102
 host: thinkdrinkdrive.direct.gov.uk
 global: =301 http://think.direct.gov.uk/drink-driving.html
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_thinkdrugdrive.yml
+++ b/data/transition-sites/directgov_thinkdrugdrive.yml
@@ -8,5 +8,3 @@ tna_timestamp: 2020101010101010 # Plug for missing timestamp
 host: thinkdrugdrive.direct.gov.uk
 global: =301 http://think.direct.gov.uk/drug-driving.html
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_thinkfatigue.yml
+++ b/data/transition-sites/directgov_thinkfatigue.yml
@@ -8,5 +8,3 @@ tna_timestamp: 2020101010101010 # Plug for missing timestamp
 host: thinkfatigue.direct.gov.uk
 global: =301 http://think.direct.gov.uk/fatigue.html
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_thinkhorsesense.yml
+++ b/data/transition-sites/directgov_thinkhorsesense.yml
@@ -8,5 +8,3 @@ tna_timestamp: 2020101010101010 # Plug for missing timestamp
 host: thinkhorsesense.direct.gov.uk
 global: =301 http://think.direct.gov.uk/horses.html
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_thinkmobiles.yml
+++ b/data/transition-sites/directgov_thinkmobiles.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20120905095108
 host: thinkmobiles.direct.gov.uk
 global: =301 http://think.direct.gov.uk/mobile-phones.html
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_thinkseatbelts.yml
+++ b/data/transition-sites/directgov_thinkseatbelts.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20120905103903
 host: thinkseatbelts.direct.gov.uk
 global: =301 http://think.direct.gov.uk/seat-belts.html
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_thinkspeed.yml
+++ b/data/transition-sites/directgov_thinkspeed.yml
@@ -8,5 +8,3 @@ tna_timestamp: 20120905095106
 host: thinkspeed.direct.gov.uk
 global: =301 http://think.direct.gov.uk/speed.html
 css: directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_togetherwecan.yml
+++ b/data/transition-sites/directgov_togetherwecan.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_unimoney.yml
+++ b/data/transition-sites/directgov_unimoney.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_whatsnext.yml
+++ b/data/transition-sites/directgov_whatsnext.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_whyletdrinkdecide.yml
+++ b/data/transition-sites/directgov_whyletdrinkdecide.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_wouldyou.yml
+++ b/data/transition-sites/directgov_wouldyou.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_yourfuture.yml
+++ b/data/transition-sites/directgov_yourfuture.yml
@@ -11,5 +11,3 @@ homepage: https://www.gov.uk
 title: Directgov
 aliases:
 - www.yourfuture.direct.gov.uk
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/directgov_yp.yml
+++ b/data/transition-sites/directgov_yp.yml
@@ -9,5 +9,3 @@ global: =410
 css: directgov
 homepage: https://www.gov.uk
 title: Directgov
-extra_organisation_slugs:
-- government-digital-service


### PR DESCRIPTION
Having the organisation in whitehall_slug and extra_organisations means that a
site is listed twice on that organisation's page.
