### PR TITLE
Make 4 fake tna_timestamps the right length

### DIFF
--- a/data/transition-sites/directgov_renewyourtaxcredits.yml
+++ b/data/transition-sites/directgov_renewyourtaxcredits.yml
@@ -4,7 +4,7 @@ whitehall_slug: government-digital-service
 title: Government Digital Service
 redirection_date: 17th October 2012
 homepage: https://www.gov.uk/government/organisations/government-digital-service
-tna_timestamp: 2020101010101010 # Plug for missing timestamp
+tna_timestamp: 20201010101010 # Plug for missing timestamp
 host: renewyourtaxcredits.direct.gov.uk
 global: =301 https://www.gov.uk/browse/benefits/tax-credits
 css: directgov

--- a/data/transition-sites/directgov_thinkdrugdrive.yml
+++ b/data/transition-sites/directgov_thinkdrugdrive.yml
@@ -4,7 +4,7 @@ whitehall_slug: government-digital-service
 title: Government Digital Service
 redirection_date: 17th October 2012
 homepage: https://www.gov.uk/government/organisations/government-digital-service
-tna_timestamp: 2020101010101010 # Plug for missing timestamp
+tna_timestamp: 20201010101010 # Plug for missing timestamp
 host: thinkdrugdrive.direct.gov.uk
 global: =301 http://think.direct.gov.uk/drug-driving.html
 css: directgov

--- a/data/transition-sites/directgov_thinkfatigue.yml
+++ b/data/transition-sites/directgov_thinkfatigue.yml
@@ -4,7 +4,7 @@ whitehall_slug: government-digital-service
 title: Government Digital Service
 redirection_date: 17th October 2012
 homepage: https://www.gov.uk/government/organisations/government-digital-service
-tna_timestamp: 2020101010101010 # Plug for missing timestamp
+tna_timestamp: 20201010101010 # Plug for missing timestamp
 host: thinkfatigue.direct.gov.uk
 global: =301 http://think.direct.gov.uk/fatigue.html
 css: directgov

--- a/data/transition-sites/directgov_thinkhorsesense.yml
+++ b/data/transition-sites/directgov_thinkhorsesense.yml
@@ -4,7 +4,7 @@ whitehall_slug: government-digital-service
 title: Government Digital Service
 redirection_date: 17th October 2012
 homepage: https://www.gov.uk/government/organisations/government-digital-service
-tna_timestamp: 2020101010101010 # Plug for missing timestamp
+tna_timestamp: 20201010101010 # Plug for missing timestamp
 host: thinkhorsesense.direct.gov.uk
 global: =301 http://think.direct.gov.uk/horses.html
 css: directgov


### PR DESCRIPTION
When these were imported with 2 extra digits, they were silently
coerced to '0000-00-00 00:00:00' in the database, which is then
treated as nil by Rails, which caused errors on their site dashboards
in Transition.
