### PR TITLE
Fix actonco2 abbr

### DIFF
--- a/data/transition-sites/directgov_actonco2.yml
+++ b/data/transition-sites/directgov_actonco2.yml
@@ -1,5 +1,5 @@
 ---
-site: directgov_www.actonco2
+site: directgov_actonco2
 whitehall_slug: government-digital-service
 redirection_date: 17th October 2012
 tna_timestamp: 20130221160721


### PR DESCRIPTION
The abbr was inconsistent with the filename, but was also breaking transition
as it uses the abbr in it's URLs for a site, and Rails thinks the full stop
indicates a format/file extension.

I'll need to manually fix the slug in the database.
