### PR TITLE
Reinstate businesslink homepage redirection

### DIFF
--- a/configs/businesslink.conf
+++ b/configs/businesslink.conf
@@ -40,6 +40,9 @@ server {
         rewrite ^(.*)$ http://www.nibusinessinfo.co.uk$1 permanent;
     }
 
+    # root url ('homepage')
+    location = / { return 301 https://www.gov.uk; }
+
     # generated location based mappings
     include /var/apps/redirector/maps/businesslink/www.businesslink.gov.uk.conf;
 


### PR DESCRIPTION
The businesslink homepages are not being redirected, and are returning 404
instead. This reinstates what I think was doing this redirect. It was removed
in: 3b5ad00bc1c894757ab21d3a123e802bcc816c56

cc @Shotclog 
