### PR TITLE
[BusinessLink] Don't throw away other querystrings

### DIFF
--- a/lib/Mappings/Businesslink.pm
+++ b/lib/Mappings/Businesslink.pm
@@ -40,8 +40,11 @@ sub get_map_key {
         my $page = $1;
         $key = "page=$page";
     }
+    else {
+        $key = $query_string;
+    }
 
-    return $key; 
+    return $key;
 }
 
 1;


### PR DESCRIPTION
When building nginx config files, don't ignore querystring parameters which
aren't one of the hardcoded set: topicid itemid and page. Instead allow them to
be used in mappings.

This fixes our inability to add mappings for old URLs which include other query
parameters, specifically agency_id and service_id which are used for
"piplinks".

Aside: Before we can switch the BusinessLink site to Transition, we will need to
replace this logic with mappings, but that will mean generating lots of
mappings to accomodate the permutations.
