### PR TITLE
Make fera.defra.gov.uk primary domain for FERA

### DIFF
--- a/data/transition-sites/fera.yml
+++ b/data/transition-sites/fera.yml
@@ -4,8 +4,8 @@ whitehall_slug: the-food-and-environment-research-agency
 redirection_date: 31st October 2014
 homepage: https://www.gov.uk/government/organisations/the-food-and-environment-research-agency
 tna_timestamp: 20131103143441
-host: www.fera.defra.gov.uk
+host: fera.defra.gov.uk
 homepage_furl: www.gov.uk/fera
 aliases:
-- fera.defra.gov.uk
+- www.fera.defra.gov.uk
 options: --query-string id


### PR DESCRIPTION
FERA has aka-fera.defra.gov.uk set up as their main AKA domain. 

In order for the transition tool to provide access to the side-by-side browser, it needs to determine that an AKA domain exists. This pull request reverses the alias from the main domain on this site, allowing that detection to occur, and to open the feature.
