### PR TITLE
Configure www.mcga.gov.uk with global path preservation to dft.gov.uk

### DIFF
--- a/data/transition-sites/mcga.yml
+++ b/data/transition-sites/mcga.yml
@@ -6,7 +6,15 @@ homepage: https://www.gov.uk/government/organisations/maritime-and-coastguard-ag
 tna_timestamp: 20140305221616
 host: www.mcga.gov.uk
 homepage_furl: www.gov.uk/mca
-global: =301 https://www.gov.uk/government/organisations/maritime-and-coastguard-agency
-# We considered adding a global 301 preserving path to www.dft.gov.uk/mca, however this
-# would send homepage traffic to the DFT homepage, rather than the MCA. Global 301 without
-# path was deemed a more favourable option
+global: =301 http://www.dft.gov.uk/mca
+global_redirect_append_path: true
+
+# This global_redirect_append_path peforms redirects at the site root:
+#
+#   www.mcga.gov.uk/foo/bar       --> www.dft.gov.uk/mca/foo/bar
+#
+# Additionally, we have rules in Bouncer which are applied before the global
+# redirect which perform redirects like this:
+#
+#   www.mcga.gov.uk/c4mca/foo/bar --> www.dft.gov.uk/mca/foo/bar
+#   www.mcga.gov.uk/mca/foo/bar   --> www.dft.gov.uk/mca/foo/bar


### PR DESCRIPTION
This config change is to accommodate the combination of www.mcga.gov.uk into the DfT main site at www.dft.gov.uk/mca

There are some additional rules in bouncer required to make this particular transition work fully in the transition app.
