### PR TITLE
Config nationalcollege.org.uk to match go-live plan

### DIFF
--- a/data/transition-sites/nctl.yml
+++ b/data/transition-sites/nctl.yml
@@ -1,9 +1,9 @@
 ---
 site: nctl
 whitehall_slug: national-college-for-teaching-and-leadership
-redirection_date: 1st September 2014
+redirection_date: 22nd September 2014
 homepage: https://www.gov.uk/government/organisations/national-college-for-teaching-and-leadership
-tna_timestamp: 20140701125459
+tna_timestamp: 20140719134807
 host: www.nationalcollege.org.uk
 homepage_furl: www.gov.uk/nctl
 aliases:
@@ -11,3 +11,4 @@ aliases:
 - www1.nationalcollege.org.uk
 - www2.nationalcollege.org.uk
 options: --query-string filename:id
+special_redirect_strategy: via_aka


### PR DESCRIPTION
The transition is to use the GOV.UK transition tool to archive an old site, while keeping the namespace alive to be used with a new site at /cms/ 

| Type of URL | Expected Result |
| --- | --- |
| [Homepage](http://www.nationalcollege.org.uk/) | To remain live, pointing at new host, self served |
| [New CMS URLs](http://www.nationalcollege.org.uk/cms-something/something) | To point at new host, with self served page |
| [Previous site URLs](http://www.nationalcollege.org.uk/index/resources/leadingschools.htm) | To resolve to GDS transition tool, likely archived |
| [All other URLs](http://www.nationalcollege.org.uk/foo/bar) | To point at GDS transition tool, resolving as 404 |

_Note: these URLS haven't been confirmed by DfE at the time of writing, they may be incorrect - will edit if so_  
