### PR TITLE
Configure KTP Online in the transition tool

### DIFF
--- a/data/transition-sites/innovateuk_ktp.yml
+++ b/data/transition-sites/innovateuk_ktp.yml
@@ -8,4 +8,4 @@ aliases:
 - ktponline.org.uk
 - www.ktponline.co.uk
 - ktponline.co.uk
-options: # No querystring analysis.
+options: --query-string vpid


### PR DESCRIPTION
They have a redirection date of 1st October 2014 according to the ticket. Need to set this in the new way: note to self.
