### PR TITLE
Remove nonsense tld redirect

### DIFF
--- a/tld/ago.uk
+++ b/tld/ago.uk
@@ -1,4 +1,0 @@
-server {
-  server_name		ago.uk;
-  rewrite ^/(.*) http://www.ago.uk/$1 permanent;
-}


### PR DESCRIPTION
The domain ago.uk doesn't appear to have ever existed. I suspect it was a typo
of ago.gov.uk. ago.gov.uk isn't being redirected by us.
