### PR TITLE
Update the slug & homepage for the newly named Certification Officer

### DIFF
--- a/data/transition-sites/certoffice.yml
+++ b/data/transition-sites/certoffice.yml
@@ -1,7 +1,7 @@
 ---
 site: certoffice
-whitehall_slug: certification-office
-homepage: https://www.gov.uk/government/organisations/certification-office
+whitehall_slug: certification-officer
+homepage: https://www.gov.uk/government/organisations/certification-officer
 tna_timestamp: 20140103142633
 host: www.certoffice.org
 aliases:


### PR DESCRIPTION
- This discrepancy between our data and the data in whitehall was
  causing the build to fail because the `certification-office` slug no
  longer existed in whitehall because it had just changed.
