### PR TITLE
Revise name of CloudStore

### DIFF
--- a/data/transition-sites/gds_dm.yml
+++ b/data/transition-sites/gds_dm.yml
@@ -1,7 +1,7 @@
 ---
 site: gds_dm
 whitehall_slug: government-digital-service
-homepage_title: 'CloudStore'
+homepage_title: 'Digital Marketplace (formerly CloudStore)'
 homepage: https://www.gov.uk/digital-marketplace
 tna_timestamp: 20140324100726
 host: govstore.service.gov.uk


### PR DESCRIPTION
Digital Marketplace team has requested the name of the site on the homepage be changed. 

Changing it outright would cause a problem for people who were expecting to see "CloudStore" somewhere on the page; this treatment serves the middle ground and indicates the name change to any visitor, and cleanly tells them the new name as well.
