### PR TITLE
Make the site config TNA timestamp script check HTTPS too

### DIFF
--- a/lib/redirector/tna_timestamp.rb
+++ b/lib/redirector/tna_timestamp.rb
@@ -3,17 +3,19 @@ require 'nokogiri'
 
 module Redirector
   class TNATimestamp
+    TNA_BASE_URL = "http://webarchive.nationalarchives.gov.uk"
+
     def initialize(hostname)
       @hostname = hostname
     end
 
     def find
       begin
-        response = open("http://webarchive.nationalarchives.gov.uk/*/http://#{@hostname}")
+        response = open("#{TNA_BASE_URL}/*/http://#{@hostname}")
       rescue OpenURI::HTTPError
         puts "Couldn't find a crawl. Trying HTTPS..."
         begin
-          response = open("http://webarchive.nationalarchives.gov.uk/*/https://#{@hostname}")
+          response = open("#{TNA_BASE_URL}/*/https://#{@hostname}")
         rescue OpenURI::HTTPError
           $stderr.puts("TNA don't appear to have crawled this (yet) #{@hostname} Try the aliases?")
           return nil


### PR DESCRIPTION
- This came up as an issue when configuring PSN in
  580f7ae - this rake task didn't think the site had a timestamp
  because it was checking just its HTTP protocol, not HTTPS.
