### PR TITLE
Add the Government Procurement Service as an alias of CCS

### DIFF
--- a/data/transition-sites/ccs.yml
+++ b/data/transition-sites/ccs.yml
@@ -4,5 +4,7 @@ whitehall_slug: crown-commercial-service
 homepage: https://www.gov.uk/government/organisations/crown-commercial-service
 tna_timestamp: 20140403225403
 host: ccs.cabinetoffice.gov.uk
+aliases:
+- gps.cabinetoffice.gov.uk
 # options: --query-string qstring1:qstring2:qstring3
 # No query string analysis


### PR DESCRIPTION
- Following a chat with Robin, this is deemed the best way of
  configuring the Government Procurement Service's domain
  gps.cabinetoffice.gov.uk as it appears identical to the new
  ccs.cabinetoffice.gov.uk domain content-wise, and currently,
  pre-transition, it redirects to CCS. The Government Procurement
  Service has closed down.
