### PR TITLE
Add aliases for Homes and Communities Agency manuals subdomain

### DIFF
--- a/data/transition-sites/hca.yml
+++ b/data/transition-sites/hca.yml
@@ -7,4 +7,8 @@ host: www.homesandcommunities.co.uk
 homepage_furl: www.gov.uk/hca
 aliases:
 - homesandcommunities.co.uk
+# These two subdomains are created pending final availability of the manuals format.
+# Otherwise, they are direct aliases of the subset of content.
+- cfg.homesandcommunities.co.uk
+- udc.homesandcommunities.co.uk
 options: --query-string page_id:page


### PR DESCRIPTION
...for future transition

These [two](http://udc.homesandcommunities.co.uk) [subdomains](http://cfg.homesandcommunities.co.uk) are to be used for two specific manuals remaining in situ, pending the availability of the GOV.UK manuals format post their agency transition. 
