### PR TITLE
Update slug for Ofqual

### DIFF
--- a/data/transition-sites/ofqual.yml
+++ b/data/transition-sites/ofqual.yml
@@ -1,7 +1,7 @@
 ---
 site: ofqual
-whitehall_slug: office-of-qualifications-and-examinations-regulation
-homepage: https://www.gov.uk/government/organisations/office-of-qualifications-and-examinations-regulation
+whitehall_slug: ofqual
+homepage: https://www.gov.uk/government/organisations/ofqual
 tna_timestamp: 20140420174249
 host: www.ofqual.gov.uk
 homepage_furl: www.gov.uk/ofqual

--- a/data/transition-sites/ofqual_comment.yml
+++ b/data/transition-sites/ofqual_comment.yml
@@ -1,7 +1,7 @@
 ---
 site: ofqual_comment
-whitehall_slug: office-of-qualifications-and-examinations-regulation
-homepage: https://www.gov.uk/government/organisations/office-of-qualifications-and-examinations-regulation
+whitehall_slug: ofqual
+homepage: https://www.gov.uk/government/organisations/ofqual
 tna_timestamp: 20140813100319
 host: comment.ofqual.gov.uk
 homepage_furl: www.gov.uk/ofqual

--- a/data/transition-sites/ofqual_register.yml
+++ b/data/transition-sites/ofqual_register.yml
@@ -1,7 +1,7 @@
 ---
 site: ofqual_register
-whitehall_slug: office-of-qualifications-and-examinations-regulation
-homepage: https://www.gov.uk/government/organisations/office-of-qualifications-and-examinations-regulation
+whitehall_slug: ofqual
+homepage: https://www.gov.uk/government/organisations/ofqual
 tna_timestamp: 20140402162602
 host: register.ofqual.gov.uk
 homepage_furl: www.gov.uk/ofqual


### PR DESCRIPTION
The slug for this organisation has just been changed in [Whitehall](https://www.gov.uk/government/organisations/ofqual)
and [Transition](https://transition.production.alphagov.co.uk/organisations/ofqual), and needs to be changed here too so that the import
doesn't fall over.
