### PR TITLE
Revise MAA homepage to organisations path

### DIFF
--- a/data/transition-sites/mod_maa.yml
+++ b/data/transition-sites/mod_maa.yml
@@ -1,7 +1,7 @@
 ---
 site: mod_maa
 whitehall_slug: ministry-of-defence
-homepage: https://www.gov.uk/government/groups/military-aviation-authority
+homepage: https://www.gov.uk/government/organisations/military-aviation-authority
 tna_timestamp: 20140702092030
 host: maa.mod.uk
 aliases:


### PR DESCRIPTION
Between the day they were configured and the hour they went live, the MAA was moved from being a 'group' to being an 'organisation'. Unfortunately, no redirect was included and the subsequent misconfiguration was only discovered after go-live. This corrects the configuration problem, and will be rectified on next import, expected 1pm 10 Dec. 
