### PR TITLE
Ignore ordering in hosts_to_site_abbrs

### DIFF
--- a/lib/transition-config/duplicate_hosts_exception.rb
+++ b/lib/transition-config/duplicate_hosts_exception.rb
@@ -7,7 +7,7 @@ module TransitionConfig
 
     def to_s
       "Hosts found in more than one site: \n"\
-      "#{@duplicates.map { |host, site_abbrs| "#{host}: #{site_abbrs}" }.join("\n")}\n\n"
+      "#{@duplicates.map { |host, site_abbrs| "#{host}: #{site_abbrs.to_a}" }.join("\n")}\n\n"
     end
   end
 end

--- a/lib/transition-config/hosts.rb
+++ b/lib/transition-config/hosts.rb
@@ -34,7 +34,7 @@ module TransitionConfig
     def self.hosts_to_site_abbrs(masks = MASKS)
       # Default entries in the hash to empty array
       # http://stackoverflow.com/a/2552946/3726525
-      hosts_to_site_abbrs = Hash.new { |hash, key| hash[key] = [] }
+      hosts_to_site_abbrs = Hash.new { |hash, key| hash[key] = Set.new }
 
       Hosts.all(masks) do |site, host|
         hosts_to_site_abbrs[host] << site.abbr

--- a/tests/lib/redirector/hosts_test.rb
+++ b/tests/lib/redirector/hosts_test.rb
@@ -18,10 +18,10 @@ class TransitionConfigHostsTest < MiniTest::Unit::TestCase
   def test_hosts_to_site_abbrs_when_a_host_appears_twice
     hosts_to_site_abbrs = TransitionConfig::Hosts.hosts_to_site_abbrs(relative_to_tests('fixtures/duplicate_hosts_sites/*.yml'))
     expected_value = {
-      'one.local'          => ['one'],
-      'alias1.one.local'   => ['one'],
-      'alias2.one.local'   => ['one'],
-      'two.local'          => ['one', 'two'],
+      'one.local'          => ['one'].to_set,
+      'alias1.one.local'   => ['one'].to_set,
+      'alias2.one.local'   => ['one'].to_set,
+      'two.local'          => ['one', 'two'].to_set,
     }
     assert_equal expected_value, hosts_to_site_abbrs
   end


### PR DESCRIPTION
`test_hosts_to_site_abbrs_when_a_host_appears_twice` has started to [fail](https://ci-new.alphagov.co.uk/view/Transition/job/govuk_transition-config/2367/console)
[intermittently](https://ci-new.alphagov.co.uk/view/Transition/job/govuk_transition-config/2369/console) [in](https://ci-new.alphagov.co.uk/view/Transition/job/govuk_transition-config/2373/console) [CI](https://ci-new.alphagov.co.uk/view/Transition/job/govuk_transition-config/2374/console) due to differences in ordering between the actual
and expected output, but only when it is run on the new ci-slave-5
(which is Trusty, not Precise):

```
expected: {"one.local"=>["one"], "alias1.one.local"=>["one"], "alias2.one.local"=>["one"], "two.local"=>["one", "two"]}
actual:   {"two.local"=>["two", "one"], "one.local"=>["one"], "alias1.one.local"=>["one"], "alias2.one.local"=>["one"]}
```

We don't care about the ordering here, in fact, so this commit uses
sets as the values in the output rather than arrays. With this change,
the test considers the output to be equal no matter which order the
files are read.

(We don't know why files are now being read in a different order,
but it has revealed an assumption in our code which was unnecessary.)
