### PR TITLE
Change the FERA homepage to http://fera.co.uk

### DIFF
--- a/data/transition-sites/fera.yml
+++ b/data/transition-sites/fera.yml
@@ -1,10 +1,9 @@
 ---
 site: fera
 whitehall_slug: the-food-and-environment-research-agency
-homepage: https://www.gov.uk/government/organisations/animal-and-plant-health-agency
+homepage: http://fera.co.uk
 tna_timestamp: 20140904082245
 host: www.fera.defra.gov.uk
-homepage_furl: www.gov.uk/apha
 aliases:
 - fera.defra.gov.uk
 options: --query-string id


### PR DESCRIPTION
- This doesn't break any tests either here or in https://github.com/alphagov/transition. Does anyone know if this'll break anything during their actual transition, given it's not a `.gov.uk` domain? I couldn't find any prior art.
