### PR TITLE
Configure reports.ofsted.gov.uk as alias to main site

### DIFF
--- a/data/transition-sites/ofsted.yml
+++ b/data/transition-sites/ofsted.yml
@@ -7,4 +7,5 @@ host: www.ofsted.gov.uk
 homepage_furl: www.gov.uk/ofsted
 aliases:
 - ofsted.gov.uk
+- reports.ofsted.gov.uk
 options: --query-string file:id:type


### PR DESCRIPTION
reports.ofsted.gov.uk is a holding location for Ofsted inspection reports. It is a direct lift of content formerly at www.ofsted.gov.uk but is likely to be redeveloped in the next 1-2 years. When repointed to GOV.UK, this subdomain should be treated as a (partial) alias of www.ofsted.gov.uk, and [these bouncer rules](https://github.com/alphagov/bouncer/blob/master/lib/bouncer/preemptive_rules.rb#L22-28) should be amended to work with its replacement service. 
