### PR TITLE
Add path-preservation config to gds blog site

### DIFF
--- a/data/transition-sites/cabinetoffice_gds.yml
+++ b/data/transition-sites/cabinetoffice_gds.yml
@@ -8,3 +8,5 @@ homepage: https://gds.blog.gov.uk
 css: cabinet-office
 extra_organisation_slugs:
 - government-digital-service
+global: =301 https://gds.blog.gov.uk/
+global_redirect_append_path: true


### PR DESCRIPTION
This is designed to enable https://github.com/alphagov/bouncer/pull/122