### PR TITLE
Add Ofsted legacy archive test site as alias

### DIFF
--- a/data/transition-sites/ofsted.yml
+++ b/data/transition-sites/ofsted.yml
@@ -8,4 +8,5 @@ homepage_furl: www.gov.uk/ofsted
 aliases:
 - ofsted.gov.uk
 - reports.ofsted.gov.uk
+- archive.oftest.co.uk
 options: --query-string file:id:type


### PR DESCRIPTION
This domain is being used as a backdoor to the old Ofsted website. There are some mappings coming from imported content, that should be associated to the main Ofsted site. It may never transition to GOV.UK, but it's easier and more future-proofed to have it registered than import a batch of mappings manually after every content move.
