### PR TITLE
Add significant query strings for VOA site

### DIFF
--- a/data/transition-sites/voa.yml
+++ b/data/transition-sites/voa.yml
@@ -11,3 +11,4 @@ aliases:
 - cti.voa.gov.uk
 - manuals.voa.gov.uk
 - www.manuals.voa.gov.uk
+options: --query-string lcn:EBAR


### PR DESCRIPTION
http://www.voa.gov.uk/cti/refs.asp?lcn=0&EBAR=1 should redirect to http://cti.voa.gov.uk/cti/refs.asp?lcn=0&EBAR=1

The addition of these significant query strings are a necessary step to enabling this.