### PR TITLE
Add non-www screening.nhs.uk as a phe_screen alias

### DIFF
--- a/data/transition-sites/phe_screen.yml
+++ b/data/transition-sites/phe_screen.yml
@@ -6,6 +6,7 @@ homepage: https://www.gov.uk/government/organisations/public-health-england
 tna_timestamp: 20201010101010 # Stub timestamp - TBC post-TNA crawl
 host: www.screening.nhs.uk
 aliases:
+- screening.nhs.uk
 - aaa.screening.nhs.uk
 - cpd.screening.nhs.uk
 - diabeticeye.screening.nhs.uk


### PR DESCRIPTION
Thanks @jamiecobbett for mentioning this one in #1082 - it's safe to assume this is needed too, as we've done for most of the others.