### PR TITLE
Simplify the new site rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gem 'rake', '10.0.3'
 gem 'minitest', '4.7.0'
 gem 'nokogiri', '1.6.1'
-gem 'htmlentities', '4.3.1'
 gem 'gds-api-adapters', '7.22.0'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,6 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    htmlentities (4.3.1)
     link_header (0.0.7)
     lrucache (0.1.4)
       PriorityQueue (~> 0.1.2)
@@ -35,7 +34,6 @@ PLATFORMS
 
 DEPENDENCIES
   gds-api-adapters (= 7.22.0)
-  htmlentities (= 4.3.1)
   minitest (= 4.7.0)
   nokogiri (= 1.6.1)
   rake (= 10.0.3)

--- a/lib/transition-config/site.rb
+++ b/lib/transition-config/site.rb
@@ -1,5 +1,4 @@
 require 'yaml'
-require 'htmlentities'
 require 'transition-config/slugs_missing_exception'
 require 'transition-config/tna_timestamp'
 
@@ -30,10 +29,6 @@ module TransitionConfig
 
     def extra_organisation_slugs
       hash['extra_organisation_slugs']
-    end
-
-    def homepage_title
-      Site.coder.decode(hash['homepage_title'])
     end
 
     def host
@@ -90,14 +85,9 @@ module TransitionConfig
       {
         'site'             => abbr,
         'whitehall_slug'   => whitehall_slug,
-        'homepage_title'   => Site.coder.encode(homepage_title),
         'homepage'         => "https://www.gov.uk/government/organisations/#{whitehall_slug}",
         'tna_timestamp'    => tna_timestamp,
         'host'             => host,
-        'homepage_furl'    => "www.gov.uk/#{abbr}",
-        'aliases'          => %W(www1.#{host} www2.#{host}),
-        'global'           => "=301 https://www.gov.uk/government/organisations/#{whitehall_slug}",
-        'options'          => "--query-string qstring1:qstring2:qstring3"
       }
     end
 
@@ -148,10 +138,6 @@ module TransitionConfig
           'host'           => host
         }
       )
-    end
-
-    def self.coder
-      @coder ||= HTMLEntities.new
     end
   end
 end

--- a/tests/lib/redirector/site_test.rb
+++ b/tests/lib/redirector/site_test.rb
@@ -22,11 +22,6 @@ class TransitionConfigSiteTest < MiniTest::Unit::TestCase
     assert_equal 'ago', site.abbr
   end
 
-  def test_decodes_titles
-    site = TransitionConfig::Site.from_yaml(slug_check_site_filename('bis'))
-    assert_equal 'Department for Business, Innovation & Skills', site.homepage_title
-  end
-
   def test_all_hosts_with_aliases_present
     site = TransitionConfig::Site.from_yaml(duplicate_hosts_site_filename('one'))
     assert_equal ['one.local', 'alias1.one.local', 'alias2.one.local', 'two.local'], site.all_hosts


### PR DESCRIPTION
Strip it back to the required fields only, rather than generating dummy data
that requires someone to understand that it is dummy and change or remove it.