### PR TITLE
[UKTI] Add alternate Sirius Programme domain

### DIFF
--- a/data/transition-sites/ukti_sirius.yml
+++ b/data/transition-sites/ukti_sirius.yml
@@ -6,3 +6,5 @@ tna_timestamp: 20150101010101
 host: www.siriusprogramme.ukti.gov.uk
 homepage_furl: www.gov.uk/ukti
 global: =301 https://www.gov.uk/the-sirius-programme
+aliases:
+- www.siriusprogramme.com


### PR DESCRIPTION
I assume these domains were the same - it seems highly likely that they are - but I am unable to find any information about what was on www.siriusprogramme.ukti.gov.uk to prove that.