### PR TITLE
Stop using the fake "Businesslink" organisation

### DIFF
--- a/data/transition-sites/businesslink.yml
+++ b/data/transition-sites/businesslink.yml
@@ -1,5 +1,6 @@
 ---
 site: businesslink
+whitehall_slug: government-digital-service
 host: www.businesslink.gov.uk
 tna_timestamp: 20120823131012
 homepage_title: 'Business Link'
@@ -19,5 +20,3 @@ aliases:
 - msn.businesslink.gov.uk
 - sagestartup.businesslink.gov.uk
 - simplybusiness.businesslink.gov.uk
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/businesslink_budget.yml
+++ b/data/transition-sites/businesslink_budget.yml
@@ -1,10 +1,9 @@
 ---
 site: businesslink_budget
+whitehall_slug: government-digital-service
 host: budget.businesslink.gov.uk
 homepage_title: 'Business Link'
 tna_timestamp: 20121009062028
 homepage_furl: www.gov.uk
 homepage: https://www.gov.uk/government/topics/public-spending
 css: businesslink
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/businesslink_elearning.yml
+++ b/data/transition-sites/businesslink_elearning.yml
@@ -1,5 +1,6 @@
 ---
 site: businesslink_elearning
+whitehall_slug: government-digital-service
 host: elearning.businesslink.gov.uk
 tna_timestamp: 20120823131012
 homepage_furl: www.gov.uk
@@ -8,6 +9,4 @@ global: =301 https://www.gov.uk/browse/business
 css: businesslink
 aliases:
 - www.elearning.businesslink.gov.uk
-extra_organisation_slugs:
-- government-digital-service
 homepage_title: 'Business Link'

--- a/data/transition-sites/businesslink_events.yml
+++ b/data/transition-sites/businesslink_events.yml
@@ -1,5 +1,6 @@
 ---
 site: businesslink_events
+whitehall_slug: government-digital-service
 host: events.businesslink.gov.uk
 tna_timestamp: 20120823131012
 homepage_furl: www.gov.uk
@@ -8,6 +9,4 @@ global: =301 https://www.gov.uk/business-training-and-networking-events-near-you
 css: businesslink
 aliases:
 - www.events.businesslink.gov.uk
-extra_organisation_slugs:
-- government-digital-service
 homepage_title: 'Business Link'

--- a/data/transition-sites/businesslink_events_admin.yml
+++ b/data/transition-sites/businesslink_events_admin.yml
@@ -1,11 +1,10 @@
 ---
 site: businesslink_events_admin
+whitehall_slug: government-digital-service
 host: admin.events.businesslink.gov.uk
 tna_timestamp: 20120823131012
 homepage_furl: www.gov.uk
 homepage: https://admin.business-events.org.uk
 global: =301 https://admin.business-events.org.uk
 css: businesslink
-extra_organisation_slugs:
-- government-digital-service
 homepage_title: 'Business Link'

--- a/data/transition-sites/businesslink_hmrc.yml
+++ b/data/transition-sites/businesslink_hmrc.yml
@@ -1,10 +1,9 @@
 ---
 site: businesslink_hmrc
+whitehall_slug: government-digital-service
 host: hmrc.businesslink.gov.uk
 tna_timestamp: 20121009062028
 homepage_furl: www.gov.uk
 homepage: https://www.gov.uk/government/topics/public-spending
 css: businesslink
-extra_organisation_slugs:
-- government-digital-service
 homepage_title: 'Business Link'

--- a/data/transition-sites/businesslink_improve.yml
+++ b/data/transition-sites/businesslink_improve.yml
@@ -1,5 +1,6 @@
 ---
 site: businesslink_improve
+whitehall_slug: government-digital-service
 host: improve.businesslink.gov.uk
 homepage_title: 'Business Link'
 tna_timestamp: 20120823131012
@@ -9,5 +10,3 @@ global: =301 https://www.gov.uk/growing-your-business
 css: businesslink
 aliases:
 - www.improve.businesslink.gov.uk
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/businesslink_info.yml
+++ b/data/transition-sites/businesslink_info.yml
@@ -1,10 +1,9 @@
 ---
 site: businesslink_info
+whitehall_slug: government-digital-service
 host: info.businesslink.gov.uk
 homepage_title: 'Business Link'
 tna_timestamp: 20121009062028
 homepage_furl: www.gov.uk
 homepage: https://www.gov.uk
 css: businesslink
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/businesslink_tariff.yml
+++ b/data/transition-sites/businesslink_tariff.yml
@@ -1,5 +1,6 @@
 ---
 site: businesslink_tariff
+whitehall_slug: government-digital-service
 host: tariff.businesslink.gov.uk
 tna_timestamp: 20120823131012
 homepage_furl: www.gov.uk
@@ -10,5 +11,3 @@ css: businesslink
 aliases:
 - www.tariff.businesslink.gov.uk
 - content.tariff.businesslink.gov.uk
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/businesslink_ukwelcomes.yml
+++ b/data/transition-sites/businesslink_ukwelcomes.yml
@@ -1,5 +1,6 @@
 ---
 site: businesslink_ukwelcomes
+whitehall_slug: government-digital-service
 host: www.ukwelcomes.businesslink.gov.uk
 tna_timestamp: 20120823131012
 homepage_title: 'Business Link'
@@ -11,5 +12,3 @@ aliases:
 - upload.ukwelcomes.businesslink.gov.uk
 - online.ukwelcomes.businesslink.gov.uk
 - ukwelcomes.businesslink.gov.uk
-extra_organisation_slugs:
-- government-digital-service

--- a/data/transition-sites/businesslink_www2.yml
+++ b/data/transition-sites/businesslink_www2.yml
@@ -1,10 +1,9 @@
 ---
 site: businesslink_www2
+whitehall_slug: government-digital-service
 host: www2.businesslink.gov.uk
 tna_timestamp: 20121009062028
 homepage_furl: www.gov.uk
 homepage: https://www.gov.uk
 css: businesslink
-extra_organisation_slugs:
-- government-digital-service
 homepage_title: 'Business Link'

--- a/lib/transition-config/site.rb
+++ b/lib/transition-config/site.rb
@@ -8,8 +8,6 @@ module TransitionConfig
       TransitionConfig.path('data/transition-sites/*.yml')
     ]
 
-    NEVER_EXISTED_IN_WHITEHALL = %w(directgov businesslink)
-
     attr_accessor :hash
     def initialize(hash)
       self.hash = hash
@@ -64,15 +62,9 @@ module TransitionConfig
       organisations.by_slug[slug]
     end
 
-    def never_existed_in_whitehall?
-      NEVER_EXISTED_IN_WHITEHALL.any? do |prefix|
-        abbr == prefix || abbr =~ Regexp.new("^#{prefix}_.*$")
-      end
-    end
-
     def all_slugs
       [].tap do |all_slugs|
-        all_slugs.push(whitehall_slug) unless never_existed_in_whitehall?
+        all_slugs.push(whitehall_slug)
         all_slugs.concat(extra_organisation_slugs) if extra_organisation_slugs
       end
     end

--- a/tests/fixtures/slug_check_sites/businesslink.yml
+++ b/tests/fixtures/slug_check_sites/businesslink.yml
@@ -1,9 +1,0 @@
----
-site: businesslink
-host: paths.local
-aliases:
-    - alias1.paths.local
-locations:
-    - path: /
-      new: http://www.example.com/foo/bar
-      status: 301

--- a/tests/fixtures/slug_check_sites/businesslink_microsite.yml
+++ b/tests/fixtures/slug_check_sites/businesslink_microsite.yml
@@ -1,9 +1,0 @@
----
-site: businesslink_microsite
-host: paths.local
-aliases:
-    - alias1.paths.local
-locations:
-    - path: /
-      new: http://www.example.com/foo/bar
-      status: 301

--- a/tests/fixtures/slug_check_sites/directgov.yml
+++ b/tests/fixtures/slug_check_sites/directgov.yml
@@ -1,9 +1,0 @@
----
-site: directgov
-host: paths.local
-aliases:
-    - alias1.paths.local
-locations:
-    - path: /
-      new: http://www.example.com/foo/bar
-      status: 301

--- a/tests/fixtures/slug_check_sites/directgov_microsite.yml
+++ b/tests/fixtures/slug_check_sites/directgov_microsite.yml
@@ -1,9 +1,0 @@
----
-site: directgov_microsite
-host: paths.local
-aliases:
-    - alias1.paths.local
-locations:
-    - path: /
-      new: http://www.example.com/foo/bar
-      status: 301

--- a/tests/lib/redirector/site_test.rb
+++ b/tests/lib/redirector/site_test.rb
@@ -53,18 +53,6 @@ class TransitionConfigSiteTest < MiniTest::Unit::TestCase
     assert_instance_of String, slug
   end
 
-  def test_sites_never_existed_in_whitehall?
-    %w(directgov directgov_microsite businesslink businesslink_microsite).each do |site_abbr|
-      site = TransitionConfig::Site.from_yaml(slug_check_site_filename(site_abbr))
-      assert site.never_existed_in_whitehall?,
-             "Expected that #{site_abbr} never_existed_in_whitehall? to be true, got false"
-    end
-
-    ago = TransitionConfig::Site.from_yaml(slug_check_site_filename('ago'))
-    refute ago.never_existed_in_whitehall?,
-           'Expected ago to have existed in whitehall'
-  end
-
   def test_existing_site_slug_exists_in_whitehall?
     organisations_api_has_organisations(%w(attorney-generals-office))
     ago = TransitionConfig::Site.from_yaml(slug_check_site_filename('ago'))
@@ -92,11 +80,6 @@ class TransitionConfigSiteTest < MiniTest::Unit::TestCase
     assert_equal ['attorney-generals-office'], ago.all_slugs
   end
 
-  def test_all_slugs_for_businesslink
-    bl = TransitionConfig::Site.from_yaml(slug_check_site_filename('businesslink'))
-    assert_equal [], bl.all_slugs
-  end
-
   def test_missing_slugs
     organisations_api_has_organisations(%w(government-office-for-science
                                            department-for-business-innovation-skills))
@@ -116,8 +99,6 @@ class TransitionConfigSiteTest < MiniTest::Unit::TestCase
 
     assert_equal ['non-existent-slug'], exception.missing['nonexistent']
     assert_equal ['made-up-slug'], exception.missing['bis']
-    assert_nil exception.missing['directgov_microsite']
-    assert_nil exception.missing['directgov']
   end
 
   def test_site_create_fails_when_no_slug


### PR DESCRIPTION
Originally there was no Government Digital Service organisation, so the choice
was to continue with a fake organisation or use the Cabinet Office. At this
point, the fake organisations are adding more complexity than value,
particularly as we want to make changes to the way organisations are
identified. We can lose some code from the Transition app too.

Successfully imported into Transition in development.