### PR TITLE
Split out aliased PHE Screening sites into separate ones

### DIFF
--- a/data/transition-sites/phe_screen_aaa.yml
+++ b/data/transition-sites/phe_screen_aaa.yml
@@ -1,10 +1,8 @@
 ---
-site: phe_screen
+site: phe_screen_aaa
 whitehall_slug: public-health-england
-homepage_title: 'UK National Screening Committee'
+homepage_title: 'NHS Abdominal Aortic Aneurysm Screening Programme'
 homepage: https://www.gov.uk/government/organisations/public-health-england
-tna_timestamp: 20140728052215
-host: www.screening.nhs.uk
-aliases:
-- screening.nhs.uk
+tna_timestamp: 20140804005718
+host: aaa.screening.nhs.uk
 options: --query-string folder:id:monthye

--- a/data/transition-sites/phe_screen_cpd.yml
+++ b/data/transition-sites/phe_screen_cpd.yml
@@ -1,10 +1,8 @@
 ---
-site: phe_screen
+site: phe_screen_cpd
 whitehall_slug: public-health-england
-homepage_title: 'UK National Screening Committee'
+homepage_title: 'Continuing Professional Development for Screening'
 homepage: https://www.gov.uk/government/organisations/public-health-england
-tna_timestamp: 20140728052215
-host: www.screening.nhs.uk
-aliases:
-- screening.nhs.uk
+tna_timestamp: 20130502202005
+host: cpd.screening.nhs.uk
 options: --query-string folder:id:monthye

--- a/data/transition-sites/phe_screen_diabeticeye.yml
+++ b/data/transition-sites/phe_screen_diabeticeye.yml
@@ -1,10 +1,8 @@
 ---
-site: phe_screen
+site: phe_screen_diabeticeye
 whitehall_slug: public-health-england
-homepage_title: 'UK National Screening Committee'
+homepage_title: 'NHS Diabetic Eye Screening Programme'
 homepage: https://www.gov.uk/government/organisations/public-health-england
-tna_timestamp: 20140728052215
-host: www.screening.nhs.uk
-aliases:
-- screening.nhs.uk
+tna_timestamp: 20140506110415
+host: diabeticeye.screening.nhs.uk
 options: --query-string folder:id:monthye

--- a/data/transition-sites/phe_screen_fetalanomaly.yml
+++ b/data/transition-sites/phe_screen_fetalanomaly.yml
@@ -1,10 +1,8 @@
 ---
-site: phe_screen
+site: phe_screen_fetalanomaly
 whitehall_slug: public-health-england
-homepage_title: 'UK National Screening Committee'
+homepage_title: 'NHS Fetal Anomaly Screening Programme'
 homepage: https://www.gov.uk/government/organisations/public-health-england
-tna_timestamp: 20140728052215
-host: www.screening.nhs.uk
-aliases:
-- screening.nhs.uk
+tna_timestamp: 20130502190810
+host: fetalanomaly.screening.nhs.uk
 options: --query-string folder:id:monthye

--- a/data/transition-sites/phe_screen_hearing.yml
+++ b/data/transition-sites/phe_screen_hearing.yml
@@ -1,10 +1,8 @@
 ---
-site: phe_screen
+site: phe_screen_hearing
 whitehall_slug: public-health-england
-homepage_title: 'UK National Screening Committee'
+homepage_title: 'NHS Newborn Hearing Screening Programme'
 homepage: https://www.gov.uk/government/organisations/public-health-england
-tna_timestamp: 20140728052215
-host: www.screening.nhs.uk
-aliases:
-- screening.nhs.uk
+tna_timestamp: 20140505103558
+host: hearing.screening.nhs.uk
 options: --query-string folder:id:monthye

--- a/data/transition-sites/phe_screen_infectiousdiseases.yml
+++ b/data/transition-sites/phe_screen_infectiousdiseases.yml
@@ -1,0 +1,8 @@
+---
+site: phe_screen_infectiousdiseases
+whitehall_slug: public-health-england
+homepage_title: 'NHS Infectious Diseases in Pregnancy Screening Programme'
+homepage: https://www.gov.uk/government/organisations/public-health-england
+tna_timestamp: 20130502202810
+host: infectiousdiseases.screening.nhs.uk
+options: --query-string folder:id:monthye

--- a/data/transition-sites/phe_screen_newbornbloodspot.yml
+++ b/data/transition-sites/phe_screen_newbornbloodspot.yml
@@ -1,0 +1,8 @@
+---
+site: phe_screen_newbornbloodspot
+whitehall_slug: public-health-england
+homepage_title: 'NHS Newborn Blood Spot Screening Programme'
+homepage: https://www.gov.uk/government/organisations/public-health-england
+tna_timestamp: 20140505103504
+host: newbornbloodspot.screening.nhs.uk
+options: --query-string folder:id:monthye

--- a/data/transition-sites/phe_screen_newbornphysical.yml
+++ b/data/transition-sites/phe_screen_newbornphysical.yml
@@ -1,0 +1,8 @@
+---
+site: phe_screen_newbornphysical
+whitehall_slug: public-health-england
+homepage_title: 'NHS Newborn and Infant Physical Examination Programme'
+homepage: https://www.gov.uk/government/organisations/public-health-england
+tna_timestamp: 20140714142050
+host: newbornphysical.screening.nhs.uk
+options: --query-string folder:id:monthye

--- a/data/transition-sites/phe_screen_sct.yml
+++ b/data/transition-sites/phe_screen_sct.yml
@@ -1,10 +1,8 @@
 ---
-site: phe_screen
+site: phe_screen_sct
 whitehall_slug: public-health-england
-homepage_title: 'UK National Screening Committee'
+homepage_title: 'NHS Sickle Cell & Thalassaemia Screening Programme'
 homepage: https://www.gov.uk/government/organisations/public-health-england
-tna_timestamp: 20140728052215
-host: www.screening.nhs.uk
-aliases:
-- screening.nhs.uk
+tna_timestamp: 20140805034130
+host: sct.screening.nhs.uk
 options: --query-string folder:id:monthye


### PR DESCRIPTION
- Also update timestamps to be the most recent crawls, not stubs
  anymore.
- Also keep the query strings the same across the sites, because they
  were set globally for all of them in the first place.