### PR TITLE
Give access to Highways England/Highways Agency sites to both orgs

### DIFF
--- a/data/transition-sites/ha_standardsforhighways.yml
+++ b/data/transition-sites/ha_standardsforhighways.yml
@@ -1,6 +1,8 @@
 ---
 site: ha_standardsforhighways
 whitehall_slug: highways-agency
+extra_organisation_slugs:
+- highways-england
 host: www.standardsforhighways.co.uk
 tna_timestamp: 20121206042904
 homepage: https://www.gov.uk/government/organisations/highways-agency

--- a/data/transition-sites/ha_trafficengland.yml
+++ b/data/transition-sites/ha_trafficengland.yml
@@ -1,6 +1,8 @@
 ---
 site: ha_trafficengland
 whitehall_slug: highways-agency
+extra_organisation_slugs:
+- highways-england
 homepage: https://www.gov.uk/government/organisations/highways-agency
 tna_timestamp: 20130502131101
 host: www.trafficengland.com

--- a/data/transition-sites/highways.yml
+++ b/data/transition-sites/highways.yml
@@ -1,6 +1,8 @@
 ---
 site: highways
 whitehall_slug: highways-england
+extra_organisation_slugs:
+- highways-agency
 homepage: https://www.gov.uk/government/organisations/highways-england
 tna_timestamp: 20140603112028
 host: www.highways.gov.uk


### PR DESCRIPTION
Highways Agency has become Highways England. This has been modeled as the old
organisation closing and a new one being created. In Signon, some users have
been reassigned to the new organisation, some haven't. The `highways.yml` site
is associated with the new organisation, but other sites are associated with
the old one. This means that users can't access all the sites they need to.

If we make all of their sites accessible to members of (and displayed under)
both organisations, it doesn't matter which organisation the user is associated
with.