### PR TITLE
Domain alias added for nas.apprenticeships.org.uk

### DIFF
--- a/data/transition-sites/sfa_apporg.yml
+++ b/data/transition-sites/sfa_apporg.yml
@@ -7,5 +7,6 @@ tna_timestamp: 20141006151154
 host: www.apprenticeships.org.uk
 aliases:
 - apprenticeships.org.uk
+- nas.apprenticeships.org.uk
 # options: --query-string qstring1:qstring2:qstring3
 # No query string analysis done


### PR DESCRIPTION
Domain alias nas.apprenticeships.org.uk requested for apprenticeships.org.uk so that redirects can be setup.