### PR TITLE
Change firekills.direct.gov.uk to firekills.gov.uk

### DIFF
--- a/data/transition-sites/directgov_firekills.yml
+++ b/data/transition-sites/directgov_firekills.yml
@@ -5,9 +5,9 @@ homepage: https://www.gov.uk/government/organisations/government-digital-service
 extra_organisation_slugs:
 - department-for-communities-and-local-government
 tna_timestamp: 20121106112314
-host: firekills.direct.gov.uk
+host: www.firekills.gov.uk
 global: =301 https://www.gov.uk/firekills
 css: directgov
 aliases:
 - firekills.gov.uk
-- www.firekills.gov.uk
+- firekills.direct.gov.uk


### PR DESCRIPTION
This entry was originally changed in https://github.com/alphagov/transition-config/pull/1099  but the ticket now indicates some additional changes are required (see https://govuk.zendesk.com/agent/tickets/1068770).