### PR TITLE
Make firekills homepage the same as the global redirect URL

### DIFF
--- a/data/transition-sites/directgov_firekills.yml
+++ b/data/transition-sites/directgov_firekills.yml
@@ -1,7 +1,7 @@
 ---
 site: directgov_firekills
 whitehall_slug: government-digital-service
-homepage: https://www.gov.uk/government/organisations/government-digital-service
+homepage: https://www.gov.uk/firekills
 extra_organisation_slugs:
 - department-for-communities-and-local-government
 tna_timestamp: 20121106112314


### PR DESCRIPTION
Even though this site is a global redirect (so the homepage URL is never
used), it's confusing to have the homepage showing in Transition as the GDS
organisation homepage on GOV.UK. Make it the same as the redirection URL
which is conceptually the new homepage for the old site.