### PR TITLE
Configure DCLG's Planning Portal site in the Transition Tool

### DIFF
--- a/data/transition-sites/dclg_planningportal.yml
+++ b/data/transition-sites/dclg_planningportal.yml
@@ -1,0 +1,9 @@
+---
+site: dclg_planningportal
+whitehall_slug: department-for-communities-and-local-government
+homepage: https://www.gov.uk/government/organisations/department-for-communities-and-local-government
+tna_timestamp: 20150612123823
+host: planningportal.gov.uk
+#options: --query-string # No query string analysis yet done.
+aliases:
+- www.planningportal.gov.uk


### PR DESCRIPTION
- The homepage URL is likely to change, following content being written
  for a planning-specific page, but set it as the DCLG homepage for now
  so they can begin work on their mappings soon.

- Might be worth someone who isn't familiar with Transition reviewing this, so we share knowledge. :sunny: