### PR TITLE
Add www aliases for the PHE Screening sites

### DIFF
--- a/data/transition-sites/phe_screen_aaa.yml
+++ b/data/transition-sites/phe_screen_aaa.yml
@@ -6,3 +6,5 @@ homepage: https://www.gov.uk/topic/population-screening-programmes
 tna_timestamp: 20150408175925
 host: aaa.screening.nhs.uk
 options: --query-string folder:id:monthye
+aliases:
+- www.aaa.screening.nhs.uk

--- a/data/transition-sites/phe_screen_cpd.yml
+++ b/data/transition-sites/phe_screen_cpd.yml
@@ -6,3 +6,5 @@ homepage: https://www.gov.uk/government/organisations/public-health-england
 tna_timestamp: 20150408175925
 host: cpd.screening.nhs.uk
 options: --query-string folder:id:monthye
+aliases:
+- www.cpd.screening.nhs.uk

--- a/data/transition-sites/phe_screen_diabeticeye.yml
+++ b/data/transition-sites/phe_screen_diabeticeye.yml
@@ -6,3 +6,5 @@ homepage: https://www.gov.uk/topic/population-screening-programmes
 tna_timestamp: 20150408175925
 host: diabeticeye.screening.nhs.uk
 options: --query-string folder:id:monthye
+aliases:
+- www.diabeticeye.screening.nhs.uk

--- a/data/transition-sites/phe_screen_fetalanomaly.yml
+++ b/data/transition-sites/phe_screen_fetalanomaly.yml
@@ -6,3 +6,5 @@ homepage: https://www.gov.uk/topic/population-screening-programmes
 tna_timestamp: 20150408175925
 host: fetalanomaly.screening.nhs.uk
 options: --query-string folder:id:monthye
+aliases:
+- www.fetalanomaly.screening.nhs.uk

--- a/data/transition-sites/phe_screen_hearing.yml
+++ b/data/transition-sites/phe_screen_hearing.yml
@@ -6,3 +6,5 @@ homepage: https://www.gov.uk/topic/population-screening-programmes
 tna_timestamp: 20150408175925
 host: hearing.screening.nhs.uk
 options: --query-string folder:id:monthye
+aliases:
+- www.hearing.screening.nhs.uk

--- a/data/transition-sites/phe_screen_infectiousdiseases.yml
+++ b/data/transition-sites/phe_screen_infectiousdiseases.yml
@@ -6,3 +6,5 @@ homepage: https://www.gov.uk/topic/population-screening-programmes
 tna_timestamp: 20150408175925
 host: infectiousdiseases.screening.nhs.uk
 options: --query-string folder:id:monthye
+aliases:
+- www.infectiousdiseases.screening.nhs.uk

--- a/data/transition-sites/phe_screen_newbornbloodspot.yml
+++ b/data/transition-sites/phe_screen_newbornbloodspot.yml
@@ -6,3 +6,5 @@ homepage: https://www.gov.uk/topic/population-screening-programmes
 tna_timestamp: 20150408175925
 host: newbornbloodspot.screening.nhs.uk
 options: --query-string folder:id:monthye
+aliases:
+- www.newbornbloodspot.screening.nhs.uk

--- a/data/transition-sites/phe_screen_newbornphysical.yml
+++ b/data/transition-sites/phe_screen_newbornphysical.yml
@@ -6,3 +6,5 @@ homepage: https://www.gov.uk/topic/population-screening-programmes
 tna_timestamp: 20150408175925
 host: newbornphysical.screening.nhs.uk
 options: --query-string folder:id:monthye
+aliases:
+- www.newbornphysical.screening.nhs.uk

--- a/data/transition-sites/phe_screen_sct.yml
+++ b/data/transition-sites/phe_screen_sct.yml
@@ -6,3 +6,5 @@ homepage: https://www.gov.uk/topic/population-screening-programmes
 tna_timestamp: 20150408175925
 host: sct.screening.nhs.uk
 options: --query-string folder:id:monthye
+aliases:
+- www.sct.screening.nhs.uk


### PR DESCRIPTION
- PHE had configured these aliases, but we weren't set up to handle
  them, hence
  https://trello.com/c/GytVtL7B/46-add-www-aliases-to-phe-screening-sites-in-transition-config.