### PR TITLE
[#96896782] Add production alphagov.co.uk domains

### DIFF
--- a/data/transition-sites/gds_alphagov_alert.yml
+++ b/data/transition-sites/gds_alphagov_alert.yml
@@ -1,0 +1,10 @@
+---
+site: gds_alphagov_alert
+whitehall_slug: government-digital-service
+homepage: https://alert.publishing.service.gov.uk/
+host: alert.production.alphagov.co.uk
+aliases:
+- icinga.production.alphagov.co.uk
+- nagios.production.alphagov.co.uk
+global: =301 https://alert.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_apt.yml
+++ b/data/transition-sites/gds_alphagov_apt.yml
@@ -1,0 +1,9 @@
+---
+site: gds_alphagov_apt
+whitehall_slug: government-digital-service
+homepage: https://apt.publishing.service.gov.uk/
+host: apt.production.alphagov.co.uk
+aliases:
+- apt-origin.production.alphagov.co.uk
+global: =301 https://apt.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_assets-origin.yml
+++ b/data/transition-sites/gds_alphagov_assets-origin.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_assets-origin
+whitehall_slug: government-digital-service
+homepage: https://assets-origin.publishing.service.gov.uk/
+host: assets-origin.production.alphagov.co.uk
+global: =301 https://assets-origin.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_business-support-api.yml
+++ b/data/transition-sites/gds_alphagov_business-support-api.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_business-support-api
+whitehall_slug: government-digital-service
+homepage: https://business-support-api.publishing.service.gov.uk/
+host: business-support-api.production.alphagov.co.uk
+global: =301 https://business-support-api.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_collections-api.yml
+++ b/data/transition-sites/gds_alphagov_collections-api.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_collections-api
+whitehall_slug: government-digital-service
+homepage: https://collections-api.publishing.service.gov.uk/
+host: collections-api.production.alphagov.co.uk
+global: =301 https://collections-api.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_collections-publisher.yml
+++ b/data/transition-sites/gds_alphagov_collections-publisher.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_collections-publisher
+whitehall_slug: government-digital-service
+homepage: https://collections-publisher.publishing.service.gov.uk/
+host: collections-publisher.production.alphagov.co.uk
+global: =301 https://collections-publisher.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_contacts-admin.yml
+++ b/data/transition-sites/gds_alphagov_contacts-admin.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_contacts-admin
+whitehall_slug: government-digital-service
+homepage: https://contacts-admin.publishing.service.gov.uk/
+host: contacts-admin.production.alphagov.co.uk
+global: =301 https://contacts-admin.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_content-planner.yml
+++ b/data/transition-sites/gds_alphagov_content-planner.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_content-planner
+whitehall_slug: government-digital-service
+homepage: https://content-planner.publishing.service.gov.uk/
+host: content-planner.production.alphagov.co.uk
+global: =301 https://content-planner.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_deploy.yml
+++ b/data/transition-sites/gds_alphagov_deploy.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_deploy
+whitehall_slug: government-digital-service
+homepage: https://deploy.publishing.service.gov.uk/
+host: deploy.production.alphagov.co.uk
+global: =301 https://deploy.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_draft-origin.yml
+++ b/data/transition-sites/gds_alphagov_draft-origin.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_draft-origin
+whitehall_slug: government-digital-service
+homepage: https://draft-origin.publishing.service.gov.uk/
+host: draft-origin.production.alphagov.co.uk
+global: =301 https://draft-origin.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_email-alert-monitor.yml
+++ b/data/transition-sites/gds_alphagov_email-alert-monitor.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_email-alert-monitor
+whitehall_slug: government-digital-service
+homepage: https://email-alert-monitor.publishing.service.gov.uk/
+host: email-alert-monitor.production.alphagov.co.uk
+global: =301 https://email-alert-monitor.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_errbit.yml
+++ b/data/transition-sites/gds_alphagov_errbit.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_errbit
+whitehall_slug: government-digital-service
+homepage: https://errbit.publishing.service.gov.uk/
+host: errbit.production.alphagov.co.uk
+global: =301 https://errbit.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_finder-api.yml
+++ b/data/transition-sites/gds_alphagov_finder-api.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_finder-api
+whitehall_slug: government-digital-service
+homepage: https://finder-api.publishing.service.gov.uk/
+host: finder-api.production.alphagov.co.uk
+global: =301 https://finder-api.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_grafana.yml
+++ b/data/transition-sites/gds_alphagov_grafana.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_grafana
+whitehall_slug: government-digital-service
+homepage: https://grafana.publishing.service.gov.uk/
+host: grafana.production.alphagov.co.uk
+global: =301 https://grafana.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_graphite.yml
+++ b/data/transition-sites/gds_alphagov_graphite.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_graphite
+whitehall_slug: government-digital-service
+homepage: https://graphite.publishing.service.gov.uk/
+host: graphite.production.alphagov.co.uk
+global: =301 https://graphite.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_hmrc-manuals-api.yml
+++ b/data/transition-sites/gds_alphagov_hmrc-manuals-api.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_hmrc-manuals-api
+whitehall_slug: government-digital-service
+homepage: https://hmrc-manuals-api.publishing.service.gov.uk/
+host: hmrc-manuals-api.production.alphagov.co.uk
+global: =301 https://hmrc-manuals-api.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_imminence.yml
+++ b/data/transition-sites/gds_alphagov_imminence.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_imminence
+whitehall_slug: government-digital-service
+homepage: https://imminence.publishing.service.gov.uk/
+host: imminence.production.alphagov.co.uk
+global: =301 https://imminence.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_kibana.yml
+++ b/data/transition-sites/gds_alphagov_kibana.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_kibana
+whitehall_slug: government-digital-service
+homepage: https://kibana.publishing.service.gov.uk/
+host: kibana.production.alphagov.co.uk
+global: =301 https://kibana.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_maslow.yml
+++ b/data/transition-sites/gds_alphagov_maslow.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_maslow
+whitehall_slug: government-digital-service
+homepage: https://maslow.publishing.service.gov.uk/
+host: maslow.production.alphagov.co.uk
+global: =301 https://maslow.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_panopticon.yml
+++ b/data/transition-sites/gds_alphagov_panopticon.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_panopticon
+whitehall_slug: government-digital-service
+homepage: https://panopticon.publishing.service.gov.uk/
+host: panopticon.production.alphagov.co.uk
+global: =301 https://panopticon.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_policy-publisher.yml
+++ b/data/transition-sites/gds_alphagov_policy-publisher.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_policy-publisher
+whitehall_slug: government-digital-service
+homepage: https://policy-publisher.publishing.service.gov.uk/
+host: policy-publisher.production.alphagov.co.uk
+global: =301 https://policy-publisher.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_private-frontend.yml
+++ b/data/transition-sites/gds_alphagov_private-frontend.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_private-frontend
+whitehall_slug: government-digital-service
+homepage: https://private-frontend.publishing.service.gov.uk/
+host: private-frontend.production.alphagov.co.uk
+global: =301 https://private-frontend.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_publisher.yml
+++ b/data/transition-sites/gds_alphagov_publisher.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_publisher
+whitehall_slug: government-digital-service
+homepage: https://publisher.publishing.service.gov.uk/
+host: publisher.production.alphagov.co.uk
+global: =301 https://publisher.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_release.yml
+++ b/data/transition-sites/gds_alphagov_release.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_release
+whitehall_slug: government-digital-service
+homepage: https://release.publishing.service.gov.uk/
+host: release.production.alphagov.co.uk
+global: =301 https://release.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_search-admin.yml
+++ b/data/transition-sites/gds_alphagov_search-admin.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_search-admin
+whitehall_slug: government-digital-service
+homepage: https://search-admin.publishing.service.gov.uk/
+host: search-admin.production.alphagov.co.uk
+global: =301 https://search-admin.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_short-url-manager.yml
+++ b/data/transition-sites/gds_alphagov_short-url-manager.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_short-url-manager
+whitehall_slug: government-digital-service
+homepage: https://short-url-manager.publishing.service.gov.uk/
+host: short-url-manager.production.alphagov.co.uk
+global: =301 https://short-url-manager.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_signon.yml
+++ b/data/transition-sites/gds_alphagov_signon.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_signon
+whitehall_slug: government-digital-service
+homepage: https://signon.publishing.service.gov.uk/
+host: signon.production.alphagov.co.uk
+global: =301 https://signon.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_specialist-publisher.yml
+++ b/data/transition-sites/gds_alphagov_specialist-publisher.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_specialist-publisher
+whitehall_slug: government-digital-service
+homepage: https://specialist-publisher.publishing.service.gov.uk/
+host: specialist-publisher.production.alphagov.co.uk
+global: =301 https://specialist-publisher.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_support.yml
+++ b/data/transition-sites/gds_alphagov_support.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_support
+whitehall_slug: government-digital-service
+homepage: https://support.publishing.service.gov.uk/
+host: support.production.alphagov.co.uk
+global: =301 https://support.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_tariff-admin.yml
+++ b/data/transition-sites/gds_alphagov_tariff-admin.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_tariff-admin
+whitehall_slug: government-digital-service
+homepage: https://tariff-admin.publishing.service.gov.uk/
+host: tariff-admin.production.alphagov.co.uk
+global: =301 https://tariff-admin.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_transition.yml
+++ b/data/transition-sites/gds_alphagov_transition.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_transition
+whitehall_slug: government-digital-service
+homepage: https://transition.publishing.service.gov.uk/
+host: transition.production.alphagov.co.uk
+global: =301 https://transition.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_travel-advice-publisher.yml
+++ b/data/transition-sites/gds_alphagov_travel-advice-publisher.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_travel-advice-publisher
+whitehall_slug: government-digital-service
+homepage: https://travel-advice-publisher.publishing.service.gov.uk/
+host: travel-advice-publisher.production.alphagov.co.uk
+global: =301 https://travel-advice-publisher.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_whitehall-admin.yml
+++ b/data/transition-sites/gds_alphagov_whitehall-admin.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_whitehall-admin
+whitehall_slug: government-digital-service
+homepage: https://whitehall-admin.publishing.service.gov.uk/
+host: whitehall-admin.production.alphagov.co.uk
+global: =301 https://whitehall-admin.publishing.service.gov.uk/
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_www-origin.yml
+++ b/data/transition-sites/gds_alphagov_www-origin.yml
@@ -1,0 +1,7 @@
+---
+site: gds_alphagov_www-origin
+whitehall_slug: government-digital-service
+homepage: https://www-origin.publishing.service.gov.uk/
+host: www-origin.production.alphagov.co.uk
+global: =301 https://www-origin.publishing.service.gov.uk/
+global_redirect_append_path: true


### PR DESCRIPTION
This commit adds config for subdomains of `production.alphagov.co.uk`.

The subdomains I have ignored are:

- ~~alert (legacy)~~
- api (not user-facing)
- backdrop-admin (legacy)
- backend (not user-facing)
- bouncer (not user-facing)
- cache (not user-facing)
- efg (staying on alphagov)
- internalsupport (legacy?)
- licensify-admin (staying on alphagov)
- logging (not user-facing)
- logs-cdn (not user-facing)
- monitoring (doesn't work)
- offsite-backup (not user-facing)
- specialist-frontend (doesn't seem to respond)
- uploadlicence (staying on alphagov)

The intent is that all of these subdomains will redirect to their equivalent subdomain on `publishing.service.gov.uk`.

For example:

    signon.production.alphagov.co.uk/users/sign_in ->
    signon.publishing.service.gov.uk/users/sign_in

I'd appreciate review from both people familiar with the Transition app and also @alphagov/team-infrastructure-admins.

These files were generated from a script so they should all be fairly similar - except for `gds_alphagov_alert` and `gds_alphagov_apt` which contain aliases.

If this looks good I'll do a similar thing for preview subdomains.