### PR TITLE
Add preview.alphagov.co.uk hosts

### DIFF
--- a/data/transition-sites/gds_alphagov_alert-preview.yml
+++ b/data/transition-sites/gds_alphagov_alert-preview.yml
@@ -1,0 +1,11 @@
+---
+site: gds_alphagov_alert-preview
+whitehall_slug: government-digital-service
+homepage: https://alert.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: alert.preview.alphagov.co.uk
+aliases:
+- icinga.preview.alphagov.co.uk
+- nagios.preview.alphagov.co.uk
+global: =301 https://alert.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_assets-origin-preview.yml
+++ b/data/transition-sites/gds_alphagov_assets-origin-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_assets-origin-preview
+whitehall_slug: government-digital-service
+homepage: https://assets-origin.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: assets-origin.preview.alphagov.co.uk
+global: =301 https://assets-origin.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_business-support-api-preview.yml
+++ b/data/transition-sites/gds_alphagov_business-support-api-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_business-support-api-preview
+whitehall_slug: government-digital-service
+homepage: https://business-support-api.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: business-support-api.preview.alphagov.co.uk
+global: =301 https://business-support-api.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_collections-api-preview.yml
+++ b/data/transition-sites/gds_alphagov_collections-api-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_collections-api-preview
+whitehall_slug: government-digital-service
+homepage: https://collections-api.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: collections-api.preview.alphagov.co.uk
+global: =301 https://collections-api.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_collections-publisher-preview.yml
+++ b/data/transition-sites/gds_alphagov_collections-publisher-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_collections-publisher-preview
+whitehall_slug: government-digital-service
+homepage: https://collections-publisher.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: collections-publisher.preview.alphagov.co.uk
+global: =301 https://collections-publisher.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_contacts-admin-preview.yml
+++ b/data/transition-sites/gds_alphagov_contacts-admin-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_contacts-admin-preview
+whitehall_slug: government-digital-service
+homepage: https://contacts-admin.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: contacts-admin.preview.alphagov.co.uk
+global: =301 https://contacts-admin.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_deploy-preview.yml
+++ b/data/transition-sites/gds_alphagov_deploy-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_deploy-preview
+whitehall_slug: government-digital-service
+homepage: https://deploy.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: deploy.preview.alphagov.co.uk
+global: =301 https://deploy.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_draft-origin-preview.yml
+++ b/data/transition-sites/gds_alphagov_draft-origin-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_draft-origin-preview
+whitehall_slug: government-digital-service
+homepage: https://draft-origin.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: draft-origin.preview.alphagov.co.uk
+global: =301 https://draft-origin.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_email-alert-monitor-preview.yml
+++ b/data/transition-sites/gds_alphagov_email-alert-monitor-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_email-alert-monitor-preview
+whitehall_slug: government-digital-service
+homepage: https://email-alert-monitor.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: email-alert-monitor.preview.alphagov.co.uk
+global: =301 https://email-alert-monitor.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_errbit-preview.yml
+++ b/data/transition-sites/gds_alphagov_errbit-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_errbit-preview
+whitehall_slug: government-digital-service
+homepage: https://errbit.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: errbit.preview.alphagov.co.uk
+global: =301 https://errbit.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_finder-api-preview.yml
+++ b/data/transition-sites/gds_alphagov_finder-api-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_finder-api-preview
+whitehall_slug: government-digital-service
+homepage: https://finder-api.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: finder-api.preview.alphagov.co.uk
+global: =301 https://finder-api.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_grafana-preview.yml
+++ b/data/transition-sites/gds_alphagov_grafana-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_grafana-preview
+whitehall_slug: government-digital-service
+homepage: https://grafana.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: grafana.preview.alphagov.co.uk
+global: =301 https://grafana.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_graphite-preview.yml
+++ b/data/transition-sites/gds_alphagov_graphite-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_graphite-preview
+whitehall_slug: government-digital-service
+homepage: https://graphite.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: graphite.preview.alphagov.co.uk
+global: =301 https://graphite.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_hmrc-manuals-api-preview.yml
+++ b/data/transition-sites/gds_alphagov_hmrc-manuals-api-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_hmrc-manuals-api-preview
+whitehall_slug: government-digital-service
+homepage: https://hmrc-manuals-api.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: hmrc-manuals-api.preview.alphagov.co.uk
+global: =301 https://hmrc-manuals-api.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_imminence-preview.yml
+++ b/data/transition-sites/gds_alphagov_imminence-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_imminence-preview
+whitehall_slug: government-digital-service
+homepage: https://imminence.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: imminence.preview.alphagov.co.uk
+global: =301 https://imminence.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_kibana-preview.yml
+++ b/data/transition-sites/gds_alphagov_kibana-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_kibana-preview
+whitehall_slug: government-digital-service
+homepage: https://kibana.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: kibana.preview.alphagov.co.uk
+global: =301 https://kibana.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_licensify-admin-preview.yml
+++ b/data/transition-sites/gds_alphagov_licensify-admin-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_licensify-admin
+whitehall_slug: government-digital-service
+homepage: https://licensify-admin.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: licensify-admin.preview.alphagov.co.uk
+global: =301 https://licensify-admin.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_maslow-preview.yml
+++ b/data/transition-sites/gds_alphagov_maslow-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_maslow-preview
+whitehall_slug: government-digital-service
+homepage: https://maslow.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: maslow.preview.alphagov.co.uk
+global: =301 https://maslow.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_panopticon-preview.yml
+++ b/data/transition-sites/gds_alphagov_panopticon-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_panopticon-preview
+whitehall_slug: government-digital-service
+homepage: https://panopticon.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: panopticon.preview.alphagov.co.uk
+global: =301 https://panopticon.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_policy-publisher-preview.yml
+++ b/data/transition-sites/gds_alphagov_policy-publisher-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_policy-publisher-preview
+whitehall_slug: government-digital-service
+homepage: https://policy-publisher.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: policy-publisher.preview.alphagov.co.uk
+global: =301 https://policy-publisher.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_private-frontend-preview.yml
+++ b/data/transition-sites/gds_alphagov_private-frontend-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_private-frontend-preview
+whitehall_slug: government-digital-service
+homepage: https://private-frontend.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: private-frontend.preview.alphagov.co.uk
+global: =301 https://private-frontend.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_publisher-preview.yml
+++ b/data/transition-sites/gds_alphagov_publisher-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_publisher-preview
+whitehall_slug: government-digital-service
+homepage: https://publisher.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: publisher.preview.alphagov.co.uk
+global: =301 https://publisher.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_release-preview.yml
+++ b/data/transition-sites/gds_alphagov_release-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_release-preview
+whitehall_slug: government-digital-service
+homepage: https://release.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: release.preview.alphagov.co.uk
+global: =301 https://release.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_search-admin-preview.yml
+++ b/data/transition-sites/gds_alphagov_search-admin-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_search-admin-preview
+whitehall_slug: government-digital-service
+homepage: https://search-admin.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: search-admin.preview.alphagov.co.uk
+global: =301 https://search-admin.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_short-url-manager-preview.yml
+++ b/data/transition-sites/gds_alphagov_short-url-manager-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_short-url-manager-preview
+whitehall_slug: government-digital-service
+homepage: https://short-url-manager.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: short-url-manager.preview.alphagov.co.uk
+global: =301 https://short-url-manager.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_signon-preview.yml
+++ b/data/transition-sites/gds_alphagov_signon-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_signon-preview
+whitehall_slug: government-digital-service
+homepage: https://signon.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: signon.preview.alphagov.co.uk
+global: =301 https://signon.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_specialist-publisher-preview.yml
+++ b/data/transition-sites/gds_alphagov_specialist-publisher-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_specialist-publisher-preview
+whitehall_slug: government-digital-service
+homepage: https://specialist-publisher.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: specialist-publisher.preview.alphagov.co.uk
+global: =301 https://specialist-publisher.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_support-preview.yml
+++ b/data/transition-sites/gds_alphagov_support-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_support-preview
+whitehall_slug: government-digital-service
+homepage: https://support.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: support.preview.alphagov.co.uk
+global: =301 https://support.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_tariff-admin-preview.yml
+++ b/data/transition-sites/gds_alphagov_tariff-admin-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_tariff-admin-preview
+whitehall_slug: government-digital-service
+homepage: https://tariff-admin.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: tariff-admin.preview.alphagov.co.uk
+global: =301 https://tariff-admin.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_transition-preview.yml
+++ b/data/transition-sites/gds_alphagov_transition-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_transition-preview
+whitehall_slug: government-digital-service
+homepage: https://transition.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: transition.preview.alphagov.co.uk
+global: =301 https://transition.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_travel-advice-publisher-preview.yml
+++ b/data/transition-sites/gds_alphagov_travel-advice-publisher-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_travel-advice-publisher-preview
+whitehall_slug: government-digital-service
+homepage: https://travel-advice-publisher.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: travel-advice-publisher.preview.alphagov.co.uk
+global: =301 https://travel-advice-publisher.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_whitehall-admin-preview.yml
+++ b/data/transition-sites/gds_alphagov_whitehall-admin-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_whitehall-admin-preview
+whitehall_slug: government-digital-service
+homepage: https://whitehall-admin.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: whitehall-admin.preview.alphagov.co.uk
+global: =301 https://whitehall-admin.integration.publishing.service.gov.uk
+global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_www-origin-preview.yml
+++ b/data/transition-sites/gds_alphagov_www-origin-preview.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_www-origin-preview
+whitehall_slug: government-digital-service
+homepage: https://www-origin.integration.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: www-origin.preview.alphagov.co.uk
+global: =301 https://www-origin.integration.publishing.service.gov.uk
+global_redirect_append_path: true


### PR DESCRIPTION
Similar to e4972b26b0f737c8de72350c51be7229f15ba5ae, this commit adds hosts for `*.preview.alphagov.co.uk`.

It includes all the production hosts except for `apt.production.alphagov.co.uk`, because that only exists in production.

---

The domain for preview is not being changed yet, but will be changed at some point. I think it makes sense to add this config at the same time as production.