### PR TITLE
A script to filter out URLs that return HTTP 404

### DIFF
--- a/tools/strip_404s.sh
+++ b/tools/strip_404s.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Usage tools/strip_404s.sh target_file_to_strip
+#
+# From a file of URLs, or stdin, strip URLs which return a HTTP 404 response
+
+while read url
+do
+  curl --head --silent -o /dev/null --write-out '%{http_code} %{url_effective}\n' $url \
+  | awk '$1 != 404 { print $2 }'
+done < "${1:-/dev/stdin}"


### PR DESCRIPTION
Some spidering tools, like anemone don't allow you to filter by
response code, potentially leaving many 404s in our results.

This script allows you to take a list of URLs and filter out any
that return 404. Sadly this does require fetching the pages again
and long term we should look at improving the spidering tools we're
using to do this in the initial pass.