### PR TITLE
Add scripts to analyse a sites query param usage

### DIFF
--- a/tools/analyse_query_params.sh
+++ b/tools/analyse_query_params.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Usage:
+#
+#   ./analyse_query_params.sh my-file-of-urls.txt
+#
+#   cat my-file-of-urls.txt | ./analyse_query_params.sh
+#
+#
+# For the input, a list of URLs, shows which are most common query
+# parameters, Eg, those that may need to be preserved by canonicalization
+# in mappings.
+#
+# Eg:
+#    324 language
+#    162 currentURL
+#     45 url
+#      3 action
+#
+
+# Input is either file arg contents or stdin
+cat "$@" | \
+  # Capture only `?foo=bar&fooz...` of URLs that match
+  grep --only-matching '?.*$' | \
+  # Remove the leading `?` from the above
+  sed 's/^?//' | \
+  # Fix any double-encoding query params separator
+  sed 's/&amp;/\&/g' | \
+  # Split query params into one pair (`foo=bar`) per line
+  tr '&' '\n' | \
+  # Take the key of the pair (`foo` for `foo=bar`)
+  cut -d= -f1 | \
+  # count the frequency of each key, highest first
+  sort | uniq -c | sort -rn

--- a/tools/analyse_query_usage.sh
+++ b/tools/analyse_query_usage.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Usage:
+#
+#   ./analyse_query_usage.sh my-file-of-urls.txt
+#
+#   cat my-file-of-urls.txt | ./analyse_query_usage.sh
+#
+#
+# For the input, a list of URLs, shows the number of URLs that will
+# be reduced to that single URL by canonicalization unless some query
+# parameters are marked as significan.
+#
+# Eg:
+#   162 http://www.planningportal.gov.uk/PpPortalSupport/ChangeLanguage
+#    45 http://www.planningportal.gov.uk/PpWeb/jsp/redirect.jsp
+#       ...
+#
+
+# Input is either file arg contents or stdin
+cat "$@" | \
+  # Take all of the URL leading up to `?`, or all if not present
+  cut -d? -f1 | \
+  # count the frequency of each URL, highest first
+  sort | uniq -c | sort -rn


### PR DESCRIPTION
By default transition mappings will ignore any query parameters, as
they most commonly don't affect the semantic meaning of the URL.

There may be some exceptions, eg, `document.php?id=foo` that we need
to explicitly configure a transition site to ignore.

These scripts are used to work out, from a list of URLs for s site,
which query params may be be meanginful, based on frequency of use
and which URLs rely most on query params.

Note: Some of the existing scripts take a file as an argument, i've
expanded this support stdin/pipes, as i've found it really useful
to tweak input (filtering out terms, etc) without having to create
a real file each time.