### PR TITLE
Add config to transition Public Health England url

### DIFF
--- a/data/transition-sites/phe_datag.yml
+++ b/data/transition-sites/phe_datag.yml
@@ -1,0 +1,8 @@
+---
+site: phe_datag
+whitehall_slug: public-health-england
+homepage_title: PHE data and analysis tools
+homepage: https://www.gov.uk/phe-data-and-analysis-tools
+tna_timestamp: 20150505172621
+host: datagateway.phe.org.uk
+options: --query-string folder:id


### PR DESCRIPTION
PHE want to transition http://datagateway.phe.org.uk/ to
https://www.gov.uk/phe-data-and-analysis-tools and have shared the following
configuration details:

*New homepage*
https://www.gov.uk/phe-data-and-analysis-tools
*Abbreviation*
phe_datag
*Significant query parameters:*
• folder
• id
The National Archive (TNA) timestamp
TBC – expected September

cc @jamiecobbett 

[Zendesk](https://govuk.zendesk.com/agent/tickets/1101224)