### PR TITLE
Add legacytools.hpa.org.uk as an alias of phe_hpa

### DIFF
--- a/data/transition-sites/phe_hpa.yml
+++ b/data/transition-sites/phe_hpa.yml
@@ -9,3 +9,4 @@ aliases:
 - hpa.org.uk
 - www.hpa.nhs.uk
 - hpa.nhs.uk
+- legacytools.hpa.org.uk


### PR DESCRIPTION
- This was suggested as a good approach in
  https://trello.com/c/psVtDaSe/71-configure-legacytools-hpa-org-uk-in-the-transition-tool.