### PR TITLE
Revert "Configure PHE HPA's legacy tools as a new site"

### DIFF
--- a/data/transition-sites/phe_hpa_legacytools.yml
+++ b/data/transition-sites/phe_hpa_legacytools.yml
@@ -1,6 +1,0 @@
----
-site: phe_hpa_legacytools
-whitehall_slug: public-health-england
-homepage: https://www.gov.uk/government/organisations/public-health-england
-tna_timestamp: 20150318173350
-host: legacytools.hpa.org.uk


### PR DESCRIPTION
Reverts alphagov/transition-config#1121

(cc @jamiecobbett - see @jennyd's comment on the PR.)