### PR TITLE
Add config for directgov volunteering site

### DIFF
--- a/data/transition-sites/directgov_volunteering.yml
+++ b/data/transition-sites/directgov_volunteering.yml
@@ -1,0 +1,9 @@
+---
+site: directgov_volunteering
+whitehall_slug: government-digital-service
+homepage: https://www.gov.uk/government/get-involved/take-part/volunteer
+tna_timestamp: 20130430103829
+host: volunteering.direct.gov.uk
+css: directgov
+global: =301 https://www.gov.uk/government/get-involved/take-part/volunteer
+title: 'Volunteering'


### PR DESCRIPTION
Copied the style from other directgov entries. The site is no longer on the internet but you can see it here: http://webarchive.nationalarchives.gov.uk/20130430103829/http://volunteering.direct.gov.uk

https://www.pivotaltracker.com/story/show/100727058