### PR TITLE
Switch host and alias around for dclg_planningportal

### DIFF
--- a/data/transition-sites/dclg_planningportal.yml
+++ b/data/transition-sites/dclg_planningportal.yml
@@ -3,7 +3,7 @@ site: dclg_planningportal
 whitehall_slug: department-for-communities-and-local-government
 homepage: https://www.gov.uk/government/organisations/department-for-communities-and-local-government
 tna_timestamp: 20150612123823
-host: planningportal.gov.uk
+host: www.planningportal.gov.uk
 #options: --query-string # No query string analysis yet done.
 aliases:
-- www.planningportal.gov.uk
+- planningportal.gov.uk


### PR DESCRIPTION
The www domain is the main live one for this site, and has the aka domain set
up. We need the www domain to be the default one for the site so that the
links to the side-by-side browser work correctly.

The import isn't able to change the default host for a site, so I have already [manually switched](https://gist.github.com/jennyd/65ee3f3508a9e735de48) the hostnames around (including the aka ones). This change to the site YAML file is only for consistency; importing it without the manual change would have no effect.

The www host is now the [default for the site](https://transition.production.alphagov.co.uk/sites/dclg_planningportal) and the side-by-side link appears.