### PR TITLE
Remove trailing slashes from global/homepage URLs

### DIFF
--- a/data/transition-sites/alphagov_blog.yml
+++ b/data/transition-sites/alphagov_blog.yml
@@ -2,10 +2,10 @@
 site: alphagov_blog
 whitehall_slug: government-digital-service
 homepage_title: Government Digital Service blog
-homepage: https://gds.blog.gov.uk/
+homepage: https://gds.blog.gov.uk
 tna_timestamp: 20111205170001
 host: blog.alpha.gov.uk
 aliases:
 - www.blog.alpha.gov.uk
-global: =301 https://gds.blog.gov.uk/
+global: =301 https://gds.blog.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/bis_biy.yml
+++ b/data/transition-sites/bis_biy.yml
@@ -6,5 +6,5 @@ tna_timestamp: 20140402165524
 host: businessinyou.bis.gov.uk
 aliases:
 - www.businessinyou.bis.gov.uk
-global: =301 http://www.greatbusiness.gov.uk/
+global: =301 http://www.greatbusiness.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/businesslink_contractsfinder.yml
+++ b/data/transition-sites/businesslink_contractsfinder.yml
@@ -1,10 +1,10 @@
 ---
 site: businesslink_contractsfinder
 whitehall_slug: government-digital-service
-homepage: http://data.gov.uk/data/contracts-archive/
+homepage: http://data.gov.uk/data/contracts-archive
 tna_timestamp: 20141216171146
 host: contractsfinder.businesslink.gov.uk
-global: =301 http://data.gov.uk/data/contracts-archive/
+global: =301 http://data.gov.uk/data/contracts-archive
 aliases:
 - www.contractsfinder.businesslink.gov.uk
 - online.contractsfinder.businesslink.gov.uk

--- a/data/transition-sites/defra_fas.yml
+++ b/data/transition-sites/defra_fas.yml
@@ -4,7 +4,7 @@ whitehall_slug: department-for-environment-food-rural-affairs
 homepage: https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: www.farmingadviceservice.org.uk
-global: =301 http://www.defra.gov.uk/farming-advice/
+global: =301 http://www.defra.gov.uk/farming-advice
 global_redirect_append_path: true
 aliases:
 - farmingadviceservice.org.uk

--- a/data/transition-sites/dft_fuelreadyreckoner.yml
+++ b/data/transition-sites/dft_fuelreadyreckoner.yml
@@ -8,4 +8,4 @@ homepage_furl: www.gov.uk/dft
 aliases:
 - fuelreadyreckoner.org.uk
 - bl.fuelreadyreckoner.org.uk
-global: =301 http://www.freightbestpractice.org.uk/
+global: =301 http://www.freightbestpractice.org.uk

--- a/data/transition-sites/dh_hale.yml
+++ b/data/transition-sites/dh_hale.yml
@@ -1,6 +1,6 @@
 ---
 site: dh_hale
 whitehall_slug: department-of-health
-homepage: http://digitalhealth.blog.gov.uk/author/stephenhale/
+homepage: http://digitalhealth.blog.gov.uk/author/stephenhale
 tna_timestamp: 20140402154639
 host: hale.dh.gov.uk

--- a/data/transition-sites/dwp_jobcentreplus.yml
+++ b/data/transition-sites/dwp_jobcentreplus.yml
@@ -6,6 +6,6 @@ aliases:
 - jobcentreplus.gov.uk
 tna_timestamp: 20130128102031
 homepage_furl: www.gov.uk
-homepage: https://www.gov.uk/
-global: =301 https://www.gov.uk/
+homepage: https://www.gov.uk
+global: =301 https://www.gov.uk
 css: department-for-work-pensions

--- a/data/transition-sites/gds_alphagov_alert.yml
+++ b/data/transition-sites/gds_alphagov_alert.yml
@@ -1,11 +1,11 @@
 ---
 site: gds_alphagov_alert
 whitehall_slug: government-digital-service
-homepage: https://alert.publishing.service.gov.uk/
+homepage: https://alert.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: alert.production.alphagov.co.uk
 aliases:
 - icinga.production.alphagov.co.uk
 - nagios.production.alphagov.co.uk
-global: =301 https://alert.publishing.service.gov.uk/
+global: =301 https://alert.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_apt.yml
+++ b/data/transition-sites/gds_alphagov_apt.yml
@@ -1,10 +1,10 @@
 ---
 site: gds_alphagov_apt
 whitehall_slug: government-digital-service
-homepage: https://apt.publishing.service.gov.uk/
+homepage: https://apt.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: apt.production.alphagov.co.uk
 aliases:
 - apt-origin.production.alphagov.co.uk
-global: =301 https://apt.publishing.service.gov.uk/
+global: =301 https://apt.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_assets-origin.yml
+++ b/data/transition-sites/gds_alphagov_assets-origin.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_assets-origin
 whitehall_slug: government-digital-service
-homepage: https://assets-origin.publishing.service.gov.uk/
+homepage: https://assets-origin.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: assets-origin.production.alphagov.co.uk
-global: =301 https://assets-origin.publishing.service.gov.uk/
+global: =301 https://assets-origin.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_business-support-api.yml
+++ b/data/transition-sites/gds_alphagov_business-support-api.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_business-support-api
 whitehall_slug: government-digital-service
-homepage: https://business-support-api.publishing.service.gov.uk/
+homepage: https://business-support-api.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: business-support-api.production.alphagov.co.uk
-global: =301 https://business-support-api.publishing.service.gov.uk/
+global: =301 https://business-support-api.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_collections-api.yml
+++ b/data/transition-sites/gds_alphagov_collections-api.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_collections-api
 whitehall_slug: government-digital-service
-homepage: https://collections-api.publishing.service.gov.uk/
+homepage: https://collections-api.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: collections-api.production.alphagov.co.uk
-global: =301 https://collections-api.publishing.service.gov.uk/
+global: =301 https://collections-api.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_collections-publisher.yml
+++ b/data/transition-sites/gds_alphagov_collections-publisher.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_collections-publisher
 whitehall_slug: government-digital-service
-homepage: https://collections-publisher.publishing.service.gov.uk/
+homepage: https://collections-publisher.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: collections-publisher.production.alphagov.co.uk
-global: =301 https://collections-publisher.publishing.service.gov.uk/
+global: =301 https://collections-publisher.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_contacts-admin.yml
+++ b/data/transition-sites/gds_alphagov_contacts-admin.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_contacts-admin
 whitehall_slug: government-digital-service
-homepage: https://contacts-admin.publishing.service.gov.uk/
+homepage: https://contacts-admin.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: contacts-admin.production.alphagov.co.uk
-global: =301 https://contacts-admin.publishing.service.gov.uk/
+global: =301 https://contacts-admin.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_content-planner.yml
+++ b/data/transition-sites/gds_alphagov_content-planner.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_content-planner
 whitehall_slug: government-digital-service
-homepage: https://content-planner.publishing.service.gov.uk/
+homepage: https://content-planner.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: content-planner.production.alphagov.co.uk
-global: =301 https://content-planner.publishing.service.gov.uk/
+global: =301 https://content-planner.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_deploy.yml
+++ b/data/transition-sites/gds_alphagov_deploy.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_deploy
 whitehall_slug: government-digital-service
-homepage: https://deploy.publishing.service.gov.uk/
+homepage: https://deploy.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: deploy.production.alphagov.co.uk
-global: =301 https://deploy.publishing.service.gov.uk/
+global: =301 https://deploy.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_draft-origin.yml
+++ b/data/transition-sites/gds_alphagov_draft-origin.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_draft-origin
 whitehall_slug: government-digital-service
-homepage: https://draft-origin.publishing.service.gov.uk/
+homepage: https://draft-origin.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: draft-origin.production.alphagov.co.uk
-global: =301 https://draft-origin.publishing.service.gov.uk/
+global: =301 https://draft-origin.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_email-alert-monitor.yml
+++ b/data/transition-sites/gds_alphagov_email-alert-monitor.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_email-alert-monitor
 whitehall_slug: government-digital-service
-homepage: https://email-alert-monitor.publishing.service.gov.uk/
+homepage: https://email-alert-monitor.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: email-alert-monitor.production.alphagov.co.uk
-global: =301 https://email-alert-monitor.publishing.service.gov.uk/
+global: =301 https://email-alert-monitor.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_errbit.yml
+++ b/data/transition-sites/gds_alphagov_errbit.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_errbit
 whitehall_slug: government-digital-service
-homepage: https://errbit.publishing.service.gov.uk/
+homepage: https://errbit.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: errbit.production.alphagov.co.uk
-global: =301 https://errbit.publishing.service.gov.uk/
+global: =301 https://errbit.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_finder-api.yml
+++ b/data/transition-sites/gds_alphagov_finder-api.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_finder-api
 whitehall_slug: government-digital-service
-homepage: https://finder-api.publishing.service.gov.uk/
+homepage: https://finder-api.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: finder-api.production.alphagov.co.uk
-global: =301 https://finder-api.publishing.service.gov.uk/
+global: =301 https://finder-api.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_grafana.yml
+++ b/data/transition-sites/gds_alphagov_grafana.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_grafana
 whitehall_slug: government-digital-service
-homepage: https://grafana.publishing.service.gov.uk/
+homepage: https://grafana.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: grafana.production.alphagov.co.uk
-global: =301 https://grafana.publishing.service.gov.uk/
+global: =301 https://grafana.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_graphite.yml
+++ b/data/transition-sites/gds_alphagov_graphite.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_graphite
 whitehall_slug: government-digital-service
-homepage: https://graphite.publishing.service.gov.uk/
+homepage: https://graphite.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: graphite.production.alphagov.co.uk
-global: =301 https://graphite.publishing.service.gov.uk/
+global: =301 https://graphite.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_hmrc-manuals-api.yml
+++ b/data/transition-sites/gds_alphagov_hmrc-manuals-api.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_hmrc-manuals-api
 whitehall_slug: government-digital-service
-homepage: https://hmrc-manuals-api.publishing.service.gov.uk/
+homepage: https://hmrc-manuals-api.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: hmrc-manuals-api.production.alphagov.co.uk
-global: =301 https://hmrc-manuals-api.publishing.service.gov.uk/
+global: =301 https://hmrc-manuals-api.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_imminence.yml
+++ b/data/transition-sites/gds_alphagov_imminence.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_imminence
 whitehall_slug: government-digital-service
-homepage: https://imminence.publishing.service.gov.uk/
+homepage: https://imminence.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: imminence.production.alphagov.co.uk
-global: =301 https://imminence.publishing.service.gov.uk/
+global: =301 https://imminence.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_kibana.yml
+++ b/data/transition-sites/gds_alphagov_kibana.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_kibana
 whitehall_slug: government-digital-service
-homepage: https://kibana.publishing.service.gov.uk/
+homepage: https://kibana.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: kibana.production.alphagov.co.uk
-global: =301 https://kibana.publishing.service.gov.uk/
+global: =301 https://kibana.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_maslow.yml
+++ b/data/transition-sites/gds_alphagov_maslow.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_maslow
 whitehall_slug: government-digital-service
-homepage: https://maslow.publishing.service.gov.uk/
+homepage: https://maslow.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: maslow.production.alphagov.co.uk
-global: =301 https://maslow.publishing.service.gov.uk/
+global: =301 https://maslow.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_panopticon.yml
+++ b/data/transition-sites/gds_alphagov_panopticon.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_panopticon
 whitehall_slug: government-digital-service
-homepage: https://panopticon.publishing.service.gov.uk/
+homepage: https://panopticon.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: panopticon.production.alphagov.co.uk
-global: =301 https://panopticon.publishing.service.gov.uk/
+global: =301 https://panopticon.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_policy-publisher.yml
+++ b/data/transition-sites/gds_alphagov_policy-publisher.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_policy-publisher
 whitehall_slug: government-digital-service
-homepage: https://policy-publisher.publishing.service.gov.uk/
+homepage: https://policy-publisher.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: policy-publisher.production.alphagov.co.uk
-global: =301 https://policy-publisher.publishing.service.gov.uk/
+global: =301 https://policy-publisher.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_private-frontend.yml
+++ b/data/transition-sites/gds_alphagov_private-frontend.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_private-frontend
 whitehall_slug: government-digital-service
-homepage: https://private-frontend.publishing.service.gov.uk/
+homepage: https://private-frontend.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: private-frontend.production.alphagov.co.uk
-global: =301 https://private-frontend.publishing.service.gov.uk/
+global: =301 https://private-frontend.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_publisher.yml
+++ b/data/transition-sites/gds_alphagov_publisher.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_publisher
 whitehall_slug: government-digital-service
-homepage: https://publisher.publishing.service.gov.uk/
+homepage: https://publisher.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: publisher.production.alphagov.co.uk
-global: =301 https://publisher.publishing.service.gov.uk/
+global: =301 https://publisher.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_release.yml
+++ b/data/transition-sites/gds_alphagov_release.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_release
 whitehall_slug: government-digital-service
-homepage: https://release.publishing.service.gov.uk/
+homepage: https://release.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: release.production.alphagov.co.uk
-global: =301 https://release.publishing.service.gov.uk/
+global: =301 https://release.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_search-admin.yml
+++ b/data/transition-sites/gds_alphagov_search-admin.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_search-admin
 whitehall_slug: government-digital-service
-homepage: https://search-admin.publishing.service.gov.uk/
+homepage: https://search-admin.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: search-admin.production.alphagov.co.uk
-global: =301 https://search-admin.publishing.service.gov.uk/
+global: =301 https://search-admin.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_short-url-manager.yml
+++ b/data/transition-sites/gds_alphagov_short-url-manager.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_short-url-manager
 whitehall_slug: government-digital-service
-homepage: https://short-url-manager.publishing.service.gov.uk/
+homepage: https://short-url-manager.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: short-url-manager.production.alphagov.co.uk
-global: =301 https://short-url-manager.publishing.service.gov.uk/
+global: =301 https://short-url-manager.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_signon.yml
+++ b/data/transition-sites/gds_alphagov_signon.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_signon
 whitehall_slug: government-digital-service
-homepage: https://signon.publishing.service.gov.uk/
+homepage: https://signon.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: signon.production.alphagov.co.uk
-global: =301 https://signon.publishing.service.gov.uk/
+global: =301 https://signon.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_specialist-publisher.yml
+++ b/data/transition-sites/gds_alphagov_specialist-publisher.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_specialist-publisher
 whitehall_slug: government-digital-service
-homepage: https://specialist-publisher.publishing.service.gov.uk/
+homepage: https://specialist-publisher.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: specialist-publisher.production.alphagov.co.uk
-global: =301 https://specialist-publisher.publishing.service.gov.uk/
+global: =301 https://specialist-publisher.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_support.yml
+++ b/data/transition-sites/gds_alphagov_support.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_support
 whitehall_slug: government-digital-service
-homepage: https://support.publishing.service.gov.uk/
+homepage: https://support.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: support.production.alphagov.co.uk
-global: =301 https://support.publishing.service.gov.uk/
+global: =301 https://support.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_tariff-admin.yml
+++ b/data/transition-sites/gds_alphagov_tariff-admin.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_tariff-admin
 whitehall_slug: government-digital-service
-homepage: https://tariff-admin.publishing.service.gov.uk/
+homepage: https://tariff-admin.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: tariff-admin.production.alphagov.co.uk
-global: =301 https://tariff-admin.publishing.service.gov.uk/
+global: =301 https://tariff-admin.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_transition.yml
+++ b/data/transition-sites/gds_alphagov_transition.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_transition
 whitehall_slug: government-digital-service
-homepage: https://transition.publishing.service.gov.uk/
+homepage: https://transition.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: transition.production.alphagov.co.uk
-global: =301 https://transition.publishing.service.gov.uk/
+global: =301 https://transition.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_travel-advice-publisher.yml
+++ b/data/transition-sites/gds_alphagov_travel-advice-publisher.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_travel-advice-publisher
 whitehall_slug: government-digital-service
-homepage: https://travel-advice-publisher.publishing.service.gov.uk/
+homepage: https://travel-advice-publisher.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: travel-advice-publisher.production.alphagov.co.uk
-global: =301 https://travel-advice-publisher.publishing.service.gov.uk/
+global: =301 https://travel-advice-publisher.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_whitehall-admin.yml
+++ b/data/transition-sites/gds_alphagov_whitehall-admin.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_whitehall-admin
 whitehall_slug: government-digital-service
-homepage: https://whitehall-admin.publishing.service.gov.uk/
+homepage: https://whitehall-admin.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: whitehall-admin.production.alphagov.co.uk
-global: =301 https://whitehall-admin.publishing.service.gov.uk/
+global: =301 https://whitehall-admin.publishing.service.gov.uk
 global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_www-origin.yml
+++ b/data/transition-sites/gds_alphagov_www-origin.yml
@@ -1,8 +1,8 @@
 ---
 site: gds_alphagov_www-origin
 whitehall_slug: government-digital-service
-homepage: https://www-origin.publishing.service.gov.uk/
+homepage: https://www-origin.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: www-origin.production.alphagov.co.uk
-global: =301 https://www-origin.publishing.service.gov.uk/
+global: =301 https://www-origin.publishing.service.gov.uk
 global_redirect_append_path: true


### PR DESCRIPTION
The request path will be appended to the global URL, so a trailing slash
is not necessary.

Remove trailing slashes for consistency with the other configuration
files.