### PR TITLE
Remove Content Planner

### DIFF
--- a/data/transition-sites/gds_alphagov_content-planner.yml
+++ b/data/transition-sites/gds_alphagov_content-planner.yml
@@ -1,8 +1,0 @@
----
-site: gds_alphagov_content-planner
-whitehall_slug: government-digital-service
-homepage: https://content-planner.publishing.service.gov.uk
-tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
-host: content-planner.production.alphagov.co.uk
-global: =301 https://content-planner.publishing.service.gov.uk
-global_redirect_append_path: true


### PR DESCRIPTION
This application is no longer in service at
`content-planner.production.alphagov.co.uk`, so there is no need to
redirect it to `content-planner.publishing.service.gov.uk`.

I'm not sure if this change will remove this domain name from the Transition application.