### PR TITLE
Add legacytools.hpa.nhs.uk as an alias of PHE HPA's site

### DIFF
--- a/data/transition-sites/phe_hpa.yml
+++ b/data/transition-sites/phe_hpa.yml
@@ -10,3 +10,4 @@ aliases:
 - www.hpa.nhs.uk
 - hpa.nhs.uk
 - legacytools.hpa.org.uk
+- legacytools.hpa.nhs.uk


### PR DESCRIPTION
(For some reason I was looking through the Custom queue and saw https://govuk.zendesk.com/agent/tickets/1090889 and thought I'd just do it.)