### PR TITLE
Remove locations from dh and dfid config files

### DIFF
--- a/data/transition-sites/dfid.yml
+++ b/data/transition-sites/dfid.yml
@@ -8,9 +8,4 @@ tna_timestamp: 20130128103201
 homepage_furl: www.gov.uk/dfid
 homepage: https://www.gov.uk/government/organisations/department-for-international-development
 options: --query-string attach_url
-locations:
-- path: ^/r4d/(.*)$
-  operation: ~*
-  status: 301
-  new_url: http://r4d.dfid.gov.uk/$1
 css: department-for-international-development

--- a/data/transition-sites/dh.yml
+++ b/data/transition-sites/dh.yml
@@ -7,8 +7,4 @@ homepage_furl: www.gov.uk/dh
 homepage: https://www.gov.uk/government/organisations/department-of-health
 aliases:
 - dh.gov.uk
-locations:
-- path: /dh_digitalassets/
-  operation: ~*
-  status: 410
 css: department-of-health


### PR DESCRIPTION
Transition and Bouncer have never supported locations in this format - it must
be left over from Redirector.

[Mappings exist](https://transition.production.alphagov.co.uk/sites/dh/mappings?utf8=%E2%9C%93&path_contains=dh_digitalassets) for the www.dh.gov.uk `dh_digitalassets` paths, and Bouncer
already has [fallback rules](https://github.com/alphagov/bouncer/blob/9df1e56396f1791a3916d90065d34eb3b8cdc9c2/lib/bouncer/fallback_rules.rb#L17-L23) for both locations as well.