### PR TITLE
Transition of three SaBRE sites for the Ministry of Defence

### DIFF
--- a/data/transition-sites/mod_sabre.yml
+++ b/data/transition-sites/mod_sabre.yml
@@ -5,5 +5,5 @@ homepage: https://www.gov.uk/government/organisations/ministry-of-defence
 host: www.sabre.mod.uk
 tna_timestamp: 20150806090301
 aliases:
-  - sabre.mod.uk
+- sabre.mod.uk
 options: --query-string _id

--- a/data/transition-sites/mod_sabre.yml
+++ b/data/transition-sites/mod_sabre.yml
@@ -6,3 +6,4 @@ host: www.sabre.mod.uk
 tna_timestamp: 20150806090301
 aliases:
   - sabre.mod.uk
+options: --query-string _id

--- a/data/transition-sites/mod_sabre.yml
+++ b/data/transition-sites/mod_sabre.yml
@@ -7,3 +7,5 @@ tna_timestamp: 20150806090301
 aliases:
 - sabre.mod.uk
 options: --query-string _id
+extra_organisation_slugs:
+- reserve-forces-and-cadets-associations

--- a/data/transition-sites/mod_sabre.yml
+++ b/data/transition-sites/mod_sabre.yml
@@ -4,3 +4,5 @@ whitehall_slug: ministry-of-defence
 homepage: https://www.gov.uk/government/organisations/ministry-of-defence
 host: www.sabre.mod.uk
 tna_timestamp: 20150806090301
+aliases:
+  - sabre.mod.uk

--- a/data/transition-sites/mod_sabre.yml
+++ b/data/transition-sites/mod_sabre.yml
@@ -1,0 +1,6 @@
+---
+site: mod_sabre
+whitehall_slug: ministry-of-defence
+homepage: https://www.gov.uk/government/organisations/ministry-of-defence
+host: www.sabre.mod.uk
+tna_timestamp: 20150806090301

--- a/data/transition-sites/mod_sabreers.yml
+++ b/data/transition-sites/mod_sabreers.yml
@@ -1,0 +1,6 @@
+---
+site: mod_sabreers
+whitehall_slug: ministry-of-defence
+homepage: https://www.gov.uk/government/organisations/ministry-of-defence
+host: ers.sabre.mod.uk
+tna_timestamp: 20150806090301

--- a/data/transition-sites/mod_sabreers.yml
+++ b/data/transition-sites/mod_sabreers.yml
@@ -5,3 +5,5 @@ homepage: https://www.gov.uk/government/organisations/ministry-of-defence
 host: ers.sabre.mod.uk
 tna_timestamp: 20150806090301
 options: --query-string _id
+extra_organisation_slugs:
+- reserve-forces-and-cadets-associations

--- a/data/transition-sites/mod_sabreers.yml
+++ b/data/transition-sites/mod_sabreers.yml
@@ -4,3 +4,4 @@ whitehall_slug: ministry-of-defence
 homepage: https://www.gov.uk/government/organisations/ministry-of-defence
 host: ers.sabre.mod.uk
 tna_timestamp: 20150806090301
+options: --query-string _id

--- a/data/transition-sites/mod_sabretoolkit.yml
+++ b/data/transition-sites/mod_sabretoolkit.yml
@@ -4,3 +4,4 @@ whitehall_slug: ministry-of-defence
 homepage: https://www.gov.uk/government/organisations/ministry-of-defence
 host: toolkit.sabre.mod.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
+options: --query-string _id

--- a/data/transition-sites/mod_sabretoolkit.yml
+++ b/data/transition-sites/mod_sabretoolkit.yml
@@ -1,0 +1,6 @@
+---
+site: mod_sabretoolkit
+whitehall_slug: ministry-of-defence
+homepage: https://www.gov.uk/government/organisations/ministry-of-defence
+host: toolkit.sabre.mod.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA

--- a/data/transition-sites/mod_sabretoolkit.yml
+++ b/data/transition-sites/mod_sabretoolkit.yml
@@ -5,3 +5,5 @@ homepage: https://www.gov.uk/government/organisations/ministry-of-defence
 host: toolkit.sabre.mod.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 options: --query-string _id
+extra_organisation_slugs:
+- reserve-forces-and-cadets-associations


### PR DESCRIPTION
Transition of three SaBRE (Support for Britain's Reservists and employers) sites for the Ministry of Defence.

http://www.sabre.mod.uk/
https://ers.sabre.mod.uk/
http://toolkit.sabre.mod.uk/
