### PR TITLE
Make dclg_planningportal owned by Planning Inspectorate

### DIFF
--- a/data/transition-sites/dclg_planningportal.yml
+++ b/data/transition-sites/dclg_planningportal.yml
@@ -4,6 +4,5 @@ whitehall_slug: department-for-communities-and-local-government
 homepage: https://www.gov.uk/government/organisations/department-for-communities-and-local-government
 tna_timestamp: 20150612123823
 host: www.planningportal.gov.uk
-#options: --query-string # No query string analysis yet done.
 aliases:
 - planningportal.gov.uk

--- a/data/transition-sites/dclg_planningportal.yml
+++ b/data/transition-sites/dclg_planningportal.yml
@@ -1,6 +1,6 @@
 ---
 site: dclg_planningportal
-whitehall_slug: department-for-communities-and-local-government
+whitehall_slug: planning-inspectorate
 homepage: https://www.gov.uk/government/organisations/department-for-communities-and-local-government
 tna_timestamp: 20150612123823
 host: www.planningportal.gov.uk


### PR DESCRIPTION
The users who will be working on the mappings for the site belong to Planning
Inspectorate, not DCLG. Changing the `whitehall_slug` will make the site show up
in Transition under the Planning Inspectorate organisation and will allow
users who belong to that organisation to edit the site's mappings. Users from
DCLG will still be able to edit the mappings too, because members of the
parent org are also allowed to edit mappings.

This will mean that the links on the 410 pages will temporarily be confusing
(the text will say Planning Inspectorate but the link will be to DCLG's
homepage), but we're waiting for confirmation of the new domain to set as the
`homepage` and will make those links consistent at that point. This change is
being made now to sort out access control issues in Transition.

Also remove an outdated comment.