### PR TITLE
Configure the Nuclear Decommissioning Authority

### DIFF
--- a/data/transition-sites/nda.yml
+++ b/data/transition-sites/nda.yml
@@ -1,0 +1,9 @@
+---
+site: nda
+whitehall_slug: nuclear-decommissioning-authority
+homepage: https://www.gov.uk/government/organisations/nuclear-decommissioning-authority
+homepage_furl: www.gov.uk/nda
+tna_timestamp: 20150817115932
+host: www.nda.gov.uk
+aliases:
+- nda.gov.uk


### PR DESCRIPTION
- The Radioactive Waste Management's pages are on the same site, with
  the NDA doing their mappings.