### PR TITLE
[dclg_planningportal] Update the homepage and homepage_title

### DIFF
--- a/data/transition-sites/dclg_planningportal.yml
+++ b/data/transition-sites/dclg_planningportal.yml
@@ -1,7 +1,8 @@
 ---
 site: dclg_planningportal
 whitehall_slug: planning-inspectorate
-homepage: https://www.gov.uk/government/organisations/department-for-communities-and-local-government
+homepage: http://www.planningportal.co.uk
+homepage_title: 'Planning Portal'
 tna_timestamp: 20150612123823
 host: www.planningportal.gov.uk
 aliases:


### PR DESCRIPTION
We've now had confirmation that the old site's homepage should redirect to
this new domain. We also need the `homepage_title` to be set now, since the
organisation title is no longer appropriate for this domain.

I've added the domain to the redirection whitelist already.