### PR TITLE
Add licensify-admin.production.alphagov.co.uk

### DIFF
--- a/data/transition-sites/gds_alphagov_licensify-admin.yml
+++ b/data/transition-sites/gds_alphagov_licensify-admin.yml
@@ -1,0 +1,8 @@
+---
+site: gds_alphagov_licensify-admin
+whitehall_slug: government-digital-service
+homepage: https://licensify-admin.publishing.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: licensify-admin.production.alphagov.co.uk
+global: =301 https://licensify-admin.publishing.service.gov.uk
+global_redirect_append_path: true


### PR DESCRIPTION
This is an admin app which needs to be redirected to the new `publishing.service.gov.uk` hostname.