### PR TITLE
Change the default homepage for ers.sabre.mod.uk

### DIFF
--- a/data/transition-sites/mod_sabreers.yml
+++ b/data/transition-sites/mod_sabreers.yml
@@ -1,10 +1,10 @@
 ---
 site: mod_sabreers
 whitehall_slug: ministry-of-defence
-homepage: https://www.gov.uk/government/groups/defence-relationship-management
+homepage: https://www.gov.uk/government/publications/defence-employer-recognition-scheme
 host: ers.sabre.mod.uk
 tna_timestamp: 20150806090301
 options: --query-string _id
-homepage_title: 'Defence Relationship Management'
+homepage_title: 'Defence Employer Recognition Scheme'
 extra_organisation_slugs:
 - reserve-forces-and-cadets-associations


### PR DESCRIPTION
SaBRE have requested a change to the default homepage for their Employer Recognition Scheme site to:

title: Defence Employer Recognition Scheme
url: https://www.gov.uk/government/publications/defence-employer-recognition-scheme