### PR TITLE
Configure Horizon 2020 site as a global redirect

### DIFF
--- a/data/transition-sites/innovateuk_h2020.yml
+++ b/data/transition-sites/innovateuk_h2020.yml
@@ -7,3 +7,4 @@ host: www.h2020uk.org
 aliases:
 - h2020uk.org
 - h2020uk.org.uk
+global: =301 https://www.gov.uk/horizon-2020


### PR DESCRIPTION
The Horizon 2020 transition is a global 301 redirect to https://www.gov.uk/horizon-2020.