### PR TITLE
Add some HMRC global redirects

### DIFF
--- a/data/transition-sites/hmrc_businessadviceday.yml
+++ b/data/transition-sites/hmrc_businessadviceday.yml
@@ -1,0 +1,7 @@
+---
+site: hmrc_businessadviceday
+whitehall_slug: hm-revenue-customs
+homepage: https://www.gov.uk/government/organisations/hm-revenue-customs
+tna_timestamp: 20090105080326
+host: www.businessadviceday.gov.uk
+global: =301 https://www.gov.uk/government/organisations/hm-revenue-customs

--- a/data/transition-sites/hmrc_childtrustfund.yml
+++ b/data/transition-sites/hmrc_childtrustfund.yml
@@ -1,0 +1,7 @@
+---
+site: hmrc_childtrustfund
+whitehall_slug: hm-revenue-customs
+homepage: https://www.gov.uk/government/organisations/hm-revenue-customs
+tna_timestamp: 20120405110832
+host: www.childtrustfund.gov.uk
+global: =301 https://www.gov.uk/government/organisations/hm-revenue-customs

--- a/data/transition-sites/hmrc_inrev.yml
+++ b/data/transition-sites/hmrc_inrev.yml
@@ -1,0 +1,14 @@
+---
+site: hmrc_inrev
+whitehall_slug: hm-revenue-customs
+homepage: https://www.gov.uk/government/organisations/hm-revenue-customs
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: www.inrev.gov.uk
+global: =301 https://www.gov.uk/government/organisations/hm-revenue-customs
+aliases:
+- www.hmrevenueandcustoms.gov.uk
+- www.hmrevenue-customs.gov.uk
+- www.ir-efile.gov.uk
+- www.ir.gov.uk
+- www.ir-online.gov.uk
+- www.revenueandcustoms.gov.uk

--- a/data/transition-sites/hmrc_paymastergeneral.yml
+++ b/data/transition-sites/hmrc_paymastergeneral.yml
@@ -1,0 +1,7 @@
+---
+site: hmrc_paymastergeneral
+whitehall_slug: hm-revenue-customs
+homepage: https://www.gov.uk/government/organisations/office-of-hm-paymaster-general
+tna_timestamp: 20100612132909
+host: www.opg.gov.uk
+global: =301 https://www.gov.uk/government/organisations/office-of-hm-paymaster-general

--- a/data/transition-sites/voa_mycounciltax.yml
+++ b/data/transition-sites/voa_mycounciltax.yml
@@ -1,0 +1,11 @@
+---
+site: voa_mycounciltax
+whitehall_slug: valuation-office-agency
+homepage: https://www.gov.uk/government/organisations/valuation-office-agency
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: www.mycounciltax.gov.uk
+global: =301 https://www.gov.uk/government/organisations/valuation-office-agency
+aliases:
+- www.mysummaryvaluation.gov.uk
+extra_organisation_slugs:
+- hm-revenue-customs


### PR DESCRIPTION
https://govuk.zendesk.com/tickets/1176959

HMRC have asked us to configure these domains to redirect to these organisation homepages. They've said that they will handle the non-`www` domains themselves (redirecting them to `www.*`); we may add those here later on but should add the `www` ones now.

I've configured all these domains as requested on the ticket except for `www.opg.gov.uk` - from the last [TNA crawl](http://webarchive.nationalarchives.gov.uk/20100612132909/http://www.opg.gov.uk) it's clear that this wasn't related to the Office of the Public Guardian so I've configured it to redirect to https://www.gov.uk/government/organisations/office-of-hm-paymaster-general instead - we'll reply to the ticket about that.