### PR TITLE
Global redirect for passportapplication.direct.gov.uk

### DIFF
--- a/directgov_passportapplication.yml
+++ b/directgov_passportapplication.yml
@@ -1,0 +1,8 @@
+---
+site: directgov_passportapplication
+whitehall_slug: hm-passport-office
+homepage: https://passportapplication.service.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: passportapplication.direct.gov.uk
+global: =301 https://passportapplication.service.gov.uk
+global_redirect_append_path: true

--- a/directgov_passportapplication.yml
+++ b/directgov_passportapplication.yml
@@ -5,4 +5,3 @@ homepage: https://passportapplication.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: passportapplication.direct.gov.uk
 global: =301 https://passportapplication.service.gov.uk
-global_redirect_append_path: true

--- a/directgov_passportapplication.yml
+++ b/directgov_passportapplication.yml
@@ -4,4 +4,4 @@ whitehall_slug: hm-passport-office
 homepage: https://passportapplication.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: passportapplication.direct.gov.uk
-global: =301 https://passportapplication.service.gov.uk
+global: =301 https://passportapplication.service.gov.uk/ips-olc/


### PR DESCRIPTION
A request from the Home Office to add:
 - passportapplication.direct.gov.uk

As a global redirect to:
 - passportapplication.service.gov.uk

A change to the service URL was requested during the service assessment process.

https://govuk.zendesk.com/agent/tickets/1097767