### PR TITLE
[Merge with caution] Split PHE obesitywm and foodwm sites

### DIFF
--- a/data/transition-sites/phe_foodwm.yml
+++ b/data/transition-sites/phe_foodwm.yml
@@ -1,0 +1,10 @@
+---
+site: phe_foodwm
+whitehall_slug: public-health-england
+homepage: https://www.gov.uk/government/organisations/public-health-england
+tna_timestamp: 20150116154742
+host: www.foodwm.org.uk
+homepage_furl: www.gov.uk/phe
+aliases:
+- foodwm.org.uk
+global: =410

--- a/data/transition-sites/phe_obesitywm.yml
+++ b/data/transition-sites/phe_obesitywm.yml
@@ -1,12 +1,10 @@
 ---
-site: phe_foodobesitywm
+site: phe_obesitywm
 whitehall_slug: public-health-england
 homepage: https://www.gov.uk/government/organisations/public-health-england
 tna_timestamp: 20150116162451
-host: www.foodwm.org.uk
+host: www.obesitywm.org.uk
 homepage_furl: www.gov.uk/phe
 aliases:
-- foodwm.org.uk
-- www.obesitywm.org.uk
 - obesitywm.org.uk
 global: =410


### PR DESCRIPTION
We [originally configured](https://github.com/alphagov/transition-config/pull/1143) these domains as a single site because they appeared
to be identical in the archives and the timestamps seemed to work
interchangeably.

Now http://webarchive.nationalarchives.gov.uk/20150116162451/http://www.foodwm.org.uk/
returns a 401 error, so we're splitting them into two separate sites to use
the official timestamp for each one.

The [`import:revert:sites` rake task](https://github.com/alphagov/transition/blob/master/lib/tasks/import/revert.rake) will need to be run in Transition for the
already-imported `phe_foodobesitywm` site when this is merged so that the
database remains consistent when this change is imported. Please talk to @jennyd and @sihugh before merging this so that we can co-ordinate that.

https://govuk.zendesk.com/agent/tickets/1192660