### PR TITLE
Make payrollgivingcentre.com a global redirect

### DIFF
--- a/data/transition-sites/co_pgc.yml
+++ b/data/transition-sites/co_pgc.yml
@@ -9,3 +9,4 @@ aliases:
 - payrollgivingcentre.com
 extra_organisation_slugs:
 - hm-revenue-customs
+global: =301 https://www.gov.uk/payroll-giving


### PR DESCRIPTION
This site was configured last year and has a few mappings, but hasn't
transitioned yet. We now want it to be a global redirect.

https://trello.com/c/XDPVTqOX/220-transition-of-payroll-giving-centre-site