### PR TITLE
Configure healthyweight4children.org.uk as a global archive

### DIFF
--- a/data/transition-sites/phe_healthyweight4children.yml
+++ b/data/transition-sites/phe_healthyweight4children.yml
@@ -1,0 +1,10 @@
+---
+site: phe_healthyweight4children
+whitehall_slug: public-health-england
+homepage: https://www.gov.uk/government/organisations/public-health-england
+tna_timestamp: 20150107110411
+host: www.healthyweight4children.org.uk
+aliases: 
+- healthyweight4children.org.uk
+global: =410
+homepage_furl: www.gov.uk/phe


### PR DESCRIPTION
… in the transition tool.

We are using the time stamp specified in the zendesk ticket rather than the
latest one as it was specifically requested.

https://trello.com/c/5LguBnJe/195-transition-of-healthy-weight-for-children-site
https://govuk.zendesk.com/agent/tickets/1174466