### PR TITLE
Fix site abbr for gds_alphagov_licensify-admin-preview

### DIFF
--- a/data/transition-sites/gds_alphagov_licensify-admin-preview.yml
+++ b/data/transition-sites/gds_alphagov_licensify-admin-preview.yml
@@ -1,5 +1,5 @@
 ---
-site: gds_alphagov_licensify-admin
+site: gds_alphagov_licensify-admin-preview
 whitehall_slug: government-digital-service
 homepage: https://licensify-admin.integration.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA


### PR DESCRIPTION
A separate site hasn't been created for this config file because it has the
same abbr as another site. We haven't yet switched from Preview to Integration
so the uncreated site isn't live yet.

This was found by the new validation which checks that a site's abbr matches
its filename.