### PR TITLE
Add www alias for preview alphagov

### DIFF
--- a/data/transition-sites/gds_alphagov_www-origin-preview.yml
+++ b/data/transition-sites/gds_alphagov_www-origin-preview.yml
@@ -4,5 +4,7 @@ whitehall_slug: government-digital-service
 homepage: https://www-origin.integration.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: www-origin.preview.alphagov.co.uk
+aliases:
+- www.preview.alphagov.co.uk
 global: =301 https://www-origin.integration.publishing.service.gov.uk
 global_redirect_append_path: true


### PR DESCRIPTION
`www` and `www-origin` both point to the same place in preview, so they should both be redirected to the new origin.