### PR TITLE
Don't redirect to https for apt.production.alphagov.co.uk

### DIFF
--- a/data/transition-sites/gds_alphagov_apt.yml
+++ b/data/transition-sites/gds_alphagov_apt.yml
@@ -1,10 +1,10 @@
 ---
 site: gds_alphagov_apt
 whitehall_slug: government-digital-service
-homepage: https://apt.publishing.service.gov.uk
+homepage: http://apt.publishing.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: apt.production.alphagov.co.uk
 aliases:
 - apt-origin.production.alphagov.co.uk
-global: =301 https://apt.publishing.service.gov.uk
+global: =301 http://apt.publishing.service.gov.uk
 global_redirect_append_path: true


### PR DESCRIPTION
Our servers aren't capable of talking https for apt-get.