### PR TITLE
Adding config for admin.localdirect.gov.uk

### DIFF
--- a/data/transition-sites/directgov_localadmin.yml
+++ b/data/transition-sites/directgov_localadmin.yml
@@ -1,0 +1,6 @@
+---
+site: directgov_localadmin
+whitehall_slug: government-digital-service
+homepage: https://www.gov.uk/government/organisations/government-digital-service
+tna_timestamp: 20201212101010 # Stub timestamp - site is not in TNA
+host: admin.localdirect.gov.uk


### PR DESCRIPTION
This is the administration site for local.direct.gov.uk

https://trello.com/c/WqnaxNVE/248-configure-local-directgov-in-transition-tool