### PR TITLE
Add new PHE sites

### DIFF
--- a/data/transition-sites/phe_ciet.yml
+++ b/data/transition-sites/phe_ciet.yml
@@ -1,0 +1,10 @@
+---
+site: phe_ciet
+whitehall_slug: public-health-england
+homepage: https://www.gov.uk/government/organisations/public-health-england
+tna_timestamp: 20150116161153
+host: www.cietoolkit.fs-server.com
+aliases:
+- cietoolkit.fs-server.com
+global: =410
+homepage_furl: www.gov.uk/phe

--- a/data/transition-sites/phe_ram.yml
+++ b/data/transition-sites/phe_ram.yml
@@ -1,0 +1,10 @@
+---
+site: phe_ram
+whitehall_slug: public-health-england
+homepage: https://www.gov.uk/government/organisations/public-health-england
+tna_timestamp: 20150116153849
+host: www.risk-assess.fs-server.com
+aliases:
+- risk-assess.fs-server.com
+global: =410
+homepage_furl: www.gov.uk/phe


### PR DESCRIPTION
- Add config file for Risk Assessment and Management
- Add config file for Chemical Incidents and Emergencies Toolkit 

Both sites are being decommissioned and need to be added as global archives to the transition tool pointing to https://www.gov.uk/government/organisations/public-health-england

https://trello.com/c/mQd4nKFg/260-transition-of-2-phe-sites