### PR TITLE
Add validation for homepage protocols

### DIFF
--- a/lib/transition-config/required_homepage_protocol_exception.rb
+++ b/lib/transition-config/required_homepage_protocol_exception.rb
@@ -1,0 +1,13 @@
+module TransitionConfig
+  class RequiredHomepageProtocolException < RuntimeError
+    attr_reader :missing
+    def initialize(missing)
+      @missing = missing
+    end
+
+    def to_s
+      "Sites missing homepage protocols: \n"\
+      "#{@missing.map { |abbr| "#{abbr}.yml" }.join("\n")}"
+    end
+  end
+end

--- a/tests/fixtures/required_homepage_protocol_missing/ago.yml
+++ b/tests/fixtures/required_homepage_protocol_missing/ago.yml
@@ -1,0 +1,6 @@
+---
+site: ago
+whitehall_slug: attorney-generals-office
+host: www.attorneygeneral.gov.uk
+tna_timestamp: 20120816224015
+homepage: www.gov.uk/government/organisations/attorney-generals-office

--- a/tests/fixtures/required_homepage_protocol_missing/bis.yml
+++ b/tests/fixtures/required_homepage_protocol_missing/bis.yml
@@ -1,0 +1,22 @@
+---
+site: bis
+whitehall_slug: department-for-business-innovation-skills
+host: www.bis.gov.uk
+tna_timestamp: 20121212135622 # Partial: update with care - TNA will have pages from www.gov.uk
+homepage_furl: www.gov.uk/bis
+homepage: www.gov.uk/government/organisations/department-for-business-innovation-skillshttps://
+css: department-for-business-innovation-skills
+aliases:
+- bis.gov.uk
+- www2.bis.gov.uk
+- web.bis.gov.uk
+- www.web.bis.gov.uk
+- tmpcms.bis.gov.uk
+- www.tmpcms.bis.gov.uk
+extra_organisation_slugs:
+- british-hallmarking-council
+- government-office-for-science
+- insolvency-practitioners-tribunal
+- insolvency-service
+- national-measurement-office
+- uk-space-agency

--- a/tests/fixtures/required_homepage_protocol_missing/ccs.yml
+++ b/tests/fixtures/required_homepage_protocol_missing/ccs.yml
@@ -1,0 +1,9 @@
+---
+whitehall_slug: crown-commercial-service
+homepage: https://www.gov.uk/government/organisations/crown-commercial-service
+tna_timestamp: 20141129010247
+host: ccs.cabinetoffice.gov.uk
+aliases:
+- gps.cabinetoffice.gov.uk
+options: --query-string sm_field_contract_id
+special_redirect_strategy: via_aka

--- a/tests/lib/transition-config/site_test.rb
+++ b/tests/lib/transition-config/site_test.rb
@@ -127,8 +127,8 @@ class TransitionConfigSiteTest < MiniTest::Unit::TestCase
       TransitionConfig::Site.check_homepage_protocol_present!(relative_to_tests('fixtures/required_homepage_protocol_missing/*.yml'))
     end
 
-    expected = ['ago']
-    assert_equal expected, exception.missing
+    expected = ['ago', 'bis']
+    assert_equal expected, exception.missing.sort
   end
 
   def test_site_create_fails_when_no_slug

--- a/tests/lib/transition-config/site_test.rb
+++ b/tests/lib/transition-config/site_test.rb
@@ -122,6 +122,15 @@ class TransitionConfigSiteTest < MiniTest::Unit::TestCase
     assert_equal expected, exception.missing
   end
 
+  def test_checks_required_homepage_protocols_present
+    exception = assert_raises(TransitionConfig::RequiredHomepageProtocolException) do
+      TransitionConfig::Site.check_homepage_protocol_present!(relative_to_tests('fixtures/required_homepage_protocol_missing/*.yml'))
+    end
+
+    expected = ['ago']
+    assert_equal expected, exception.missing
+  end
+
   def test_site_create_fails_when_no_slug
     organisations_api_does_not_have_organisation 'non-existent-whitehall-slug'
 


### PR DESCRIPTION
- validation rake tasks now check for missing protocols in the homepage URL