### PR TITLE
Remove erpho.org.uk

### DIFF
--- a/data/transition-sites/phe_erpho.yml
+++ b/data/transition-sites/phe_erpho.yml
@@ -1,9 +1,0 @@
----
-site: phe_erpho
-whitehall_slug: public-health-england
-homepage: http://www.apho.org.uk
-tna_timestamp: 20151111133042
-host: www.erpho.org.uk
-aliases:
-- erpho.org.uk
-global: =410


### PR DESCRIPTION
PHE have decided to redirect to www.apho.org.uk so we remove erpho.org.uk from the transition tool

For https://trello.com/c/vPfzqVPC/282-remove-www-erpho-org-uk-phe-site-from-the-transition-tool-1

For deploying to production/merging into master:

1.) Disable Transition Importer
2.) Run Rake Task in transition: `rake import:revert:sites[phe_erpho]`
3.) Merge this PR
4.) Reenable Transition Importer
