### PR TITLE
Update homepage and homepage_title for www.localdirect.gov.uk

### DIFF
--- a/data/transition-sites/dclg_localdirect.yml
+++ b/data/transition-sites/dclg_localdirect.yml
@@ -1,11 +1,10 @@
 ---
 site: dclg_localdirect
 whitehall_slug: department-for-communities-and-local-government
-homepage: https://www.gov.uk/government/organisations/department-for-communities-and-local-government
-homepage_furl: www.gov.uk/dclg
+homepage: http://www.localdigitalcoalition.uk
 tna_timestamp: 20160330154530
 host: www.localdirect.gov.uk
 aliases:
 - localdirect.gov.uk
 global: =410
-css: department-for-communities-and-local-government
+homepage_title: 'Local Digital Coalition'


### PR DESCRIPTION
This site is archived at this domain, but Local Digital Coalition are going to
continue to run and update the site at a non-government domain, so we need to
link to that instead of the DCLG homepage from the archive pages.

This commit also removes the css because we don't think we need it here.