### PR TITLE
Add config for old GDS assets domain

### DIFF
--- a/data/transition-sites/gds_assets_cabinetoffice.yml
+++ b/data/transition-sites/gds_assets_cabinetoffice.yml
@@ -1,0 +1,8 @@
+---
+site: gds_assets_cabinetoffice
+whitehall_slug: government-digital-service
+homepage: https://assets.publishing.service.gov.uk
+tna_timestamp: 20160317153903
+host: assets.digital.cabinet-office.gov.uk
+global: =301 https://assets.publishing.service.gov.uk
+global_redirect_append_path: true


### PR DESCRIPTION
This is being redirected.

---

I think there's a problem with the method that gets the latest date from The National Archives. Their site looks shiny, maybe they changed it?