### PR TITLE
Fix the TNA timestamp script now that TNA have changed their site

### DIFF
--- a/lib/transition-config/tna_timestamp.rb
+++ b/lib/transition-config/tna_timestamp.rb
@@ -11,11 +11,11 @@ module TransitionConfig
 
     def find
       begin
-        response = open("#{TNA_BASE_URL}/*/http://#{@hostname}")
+        response = open("#{TNA_BASE_URL}/+/http://#{@hostname}")
       rescue OpenURI::HTTPError
         puts "Couldn't find a crawl. Trying HTTPS..."
         begin
-          response = open("#{TNA_BASE_URL}/*/https://#{@hostname}")
+          response = open("#{TNA_BASE_URL}/+/https://#{@hostname}")
         rescue OpenURI::HTTPError
           $stderr.puts("TNA don't appear to have crawled this (yet) #{@hostname} Try the aliases?")
           return nil
@@ -23,8 +23,7 @@ module TransitionConfig
       end
 
       doc = Nokogiri::HTML(response)
-      crawl_date_row = doc.css('div#pagemain table tr').last
-      most_recent_crawl_link = crawl_date_row.css('td a').last
+      most_recent_crawl_link = doc.xpath('//*[@id="header"]/div/div[1]/ul/li[6]/a').last
       url = URI.parse(most_recent_crawl_link['href'])
       url.path.split('/')[1]
     end

--- a/tests/fixtures/tna/ukba.html
+++ b/tests/fixtures/tna/ukba.html
@@ -1,82 +1,94 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-  <head>
-    <title>Internet Memory | UK Government Web Archive</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <link href="/media/css/tna.css" type="text/css" rel="stylesheet" media="all" />
-  </head>
-  <body>
-    <div id="header">
-      <a name="top"></a>
-      <div id="logo">
-        <a title="The National Archives" href="http://www.nationalarchives.gov.uk" target="_top"><img src="/media/img/logo_TNA_201005.gif" height="46" width="317" alt="The National Archives" /></a>
-      </div>
-    </div>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
+"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<!--[if lt IE 7 ]> <html class="ie6" xmlns="http://www.w3.org/1999/xhtml"
+  xml:lang="fr"> <![endif]-->
+<!--[if IE 7 ]> <html class="ie7" xmlns="http://www.w3.org/1999/xhtml"
+  xml:lang="fr"> <![endif]-->
+<!--[if IE 8 ]> <html class="ie8" xmlns="http://www.w3.org/1999/xhtml"
+  xml:lang="fr"> <![endif]-->
+<!--[if IE 9 ]> <html class="ie9" xmlns="http://www.w3.org/1999/xhtml"
+  xml:lang="fr"> <![endif]-->
+<!--[if IE 10 ]> <html class="ie10" xmlns="http://www.w3.org/1999/xhtml"
+  xml:lang="fr"> <![endif]-->
+<!--[if (gt IE 10)|!(IE)]><!-->
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr">
+<!--<![endif]-->
 
-    <div id="pagecontent">
-      <h1>UK Government Web Archive</h1>
-      <div id="searchZone">
-        <style>
-          #maintenance-warning h3 {
-          font-size: 13px;
-          }
-        </style>
-      We currently have a problem with our search facility, making it slower than
-      usual to return results. We’re working on a solution. Please accept our
-      apologies for any inconvenience.
-        <form id="search" action="http://webarchive.nationalarchives.gov.uk/search/" method="get" target="_top">
-          <fieldset class="left">
-            <div id="search-text">
-              <input class="textField" name="query" type="text" onfocus="if (this.value==this.defaultValue) this.value='';" size="50" value="Search the UK Government Web Archive" />
-            </div>
-            <div id="select-box">
-              <select name="where" class="selectField">
-                <option class="select-text" value="text">the Collection</option>
-                <option class="select-text" value="url" selected>the URLs</option>
-              </select>
-            </div>
-            <div id="search-submit">
-              <input type="image" value="submit" alt="submit" src="/media/img/search.gif" />
-            </div>
-          </fieldset>
-          <fieldset class="right">
-            <div class="search-links"><a href="http://webarchive.nationalarchives.gov.uk/adv_search/">Advanced Search</a></div>
-           </fieldset>
-        </form>
-      </div>
-      <div id="pagemain">
-        <h2>  [ live site <a href="http://www.ukba.homeoffice.gov.uk" title="" target="_blank">http://www.ukba.homeoffice.gov.uk</a> ]</h2>
-        <p></p>
-        <table>
-        <tr>
-          <td colspan="7" class="header">
-            <div id="searchTitle">
-              <div id="searchDesc">Search results for Aug 06 2008 - Jan 10 2014 </div>
-              <div id="searchResult">[263 results]</div>
-            <div>
-          </td>
-        </tr>
-          <div id="tblcontainer">
-            <tr>
-              <th>2013<br /><span class="small">[ 1 instances]</span></th>
-              <th>2014<br /><span class="small">[ 2 instances]</span></th>
-            </tr>
-            <tr>
-              <td nowrap>
-                <a href="http://webarchive.nationalarchives.gov.uk/20131202165031/http://www.ukba.homeoffice.gov.uk" class="">Dec 02 2013</a><br/>
-              </td>
-              <td nowrap>
-                <a href="http://webarchive.nationalarchives.gov.uk/20140107122627/http://www.ukba.homeoffice.gov.uk" class="">Jan 07 2014</a><br/>
-                <a href="http://webarchive.nationalarchives.gov.uk/20140110181512/http://www.ukba.homeoffice.gov.uk" class="">Jan 10 2014</a><br/>
-              </td>
-            </tr>
-          </div>
-        </table>
-      </div>
-    </div>
-    <div id="footer">
-      <a href="http://europarchive.org/about.php">About</a> | <a href=mailto:info@europarchive.org>Contact</a> |
-      <a href="http://europarchive.org/terms.php">Terms, Privacy & Copyright</a><br />
-    </div>
-  </body>
+<head>
+
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+  <meta name="author" content="Internet Memory Foundation" />
+  <meta name="keywords" content="" />
+  <meta name="description"
+    content="IMF Access Framework, easy access to web archives" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <title>[ARCHIVED CONTENT] UK Government Web Archive – The National Archives</title>
+
+  <link rel="shortcut icon" type="image/x-icon"
+    href="/tna/media_sel/images/favicon.png" />
+  <link rel="stylesheet" href="/media/helpers/blankCore/css/blank.min.css"
+    type="text/css" media="all" />
+  <link rel="stylesheet" href="/tna/template_sel/css/flat.css"
+    type="text/css" media="all" />
+
+  <script type="text/javascript"
+    src="/media/helpers/jquery-ui.custom/latest/jquery.min.js"></script>
+  <script type="text/javascript"
+    src="/media/helpers/jquery-ui.custom/latest/jquery-ui.min.js">
+  </script>
+  <script type="text/javascript"
+    src="/media/helpers/jquery-cookie/jquery.cookie.js"></script>
+  <script type="text/javascript"
+    src="/media/helpers/jQuery-hoverIndent/jquery.hoverIntent.minified.js">
+  </script>
+  <script type="text/javascript"
+    src="/media/helpers/jquery.scrollTo/jquery.scrollTo.min.js">
+  </script>
+  
+  <script type="text/javascript" src="/tna/media_sel/js/htmlOutput.js">
+  </script>
+  
+  <script type="text/javascript" src="/tna/media_sel/js/scripts.js">
+  </script>
+
+<script>
+  // Strip script from this fixture, we don't care about it.
+</script>
+
+</head>
+
+
+<body class="pageBrowser banner nopic">
+  
+<div id="flat" class="flat">
+  
+<div class="header" id="header">
+  <div class="content">
+    <a class="logo" href="http://nationalarchives.gov.uk/webarchive/">
+      <span class="accessibility">UK Government Web Archive</span></a>
+    <div class="textMention">
+            <p>This archived web content was captured on <span
+            class="mentionDate">10/01/2014</span> for
+            permanent preservation in the
+            <a href="http://nationalarchives.gov.uk/webarchive/">UK Government
+            Web Archive</a>.</p>
+            <p>We do not use cookies but some may be left in your browser
+            from archived websites.
+            <a href="https://www.nationalarchives.gov.uk/legal/cookies.htm">
+             Find out more about cookies</a>.</p>
+            <ul class="textBrowser">
+              <li class="label">Browse dates:</li>
+              <li><a href="http://webarchive.nationalarchives.gov.uk/20080806121433/http://www.ukba.homeoffice.gov.uk">First</a></li>
+              <li><a href="http://webarchive.nationalarchives.gov.uk/20140107122627/http://www.ukba.homeoffice.gov.uk">Previous</a></li>
+              <li><a href="http://webarchive.nationalarchives.gov.uk/*/http://www.ukba.homeoffice.gov.uk">Show all</a></li>
+              <li><a href="http://webarchive.nationalarchives.gov.uk/20140110181523/http://www.ukba.homeoffice.gov.uk">Next</a></li>
+              <li><a href="http://webarchive.nationalarchives.gov.uk/20150423114915/http://www.ukba.homeoffice.gov.uk">Latest</a></li>
+            </ul></div>
+    <div class="clearer">&nbsp;</div>
+  </div><!-- fin div class content -->
+</div><!-- fin div #header -->
+
+<!-- There's actual page content here, but as we're only using the (red) TNA page header, we don't need to include it. All we care about is the "Latest" link. -->
+
 </html>

--- a/tests/lib/transition-config/site_test.rb
+++ b/tests/lib/transition-config/site_test.rb
@@ -148,7 +148,7 @@ class TransitionConfigSiteTest < MiniTest::Unit::TestCase
 
   def test_site_creates_yaml_when_slug_exists
     tna_response = File.read(relative_to_tests('fixtures/tna/ukba.html'))
-    stub_request(:get, "http://webarchive.nationalarchives.gov.uk/*/http://www.ukba.homeoffice.gov.uk").
+    stub_request(:get, "http://webarchive.nationalarchives.gov.uk/+/http://www.ukba.homeoffice.gov.uk").
         to_return(status: 200, body: tna_response)
 
     organisation_details = organisation_details_for_slug('uk-borders-agency').tap do |details|
@@ -173,7 +173,7 @@ class TransitionConfigSiteTest < MiniTest::Unit::TestCase
       assert_equal 'ukba', yaml['site']
       assert_equal 'uk-borders-agency', yaml['whitehall_slug']
       assert_equal 'https://www.gov.uk/government/organisations/uk-borders-agency', yaml['homepage']
-      assert_equal 20140110181512, yaml['tna_timestamp']
+      assert_equal 20150423114915, yaml['tna_timestamp']
     ensure
       File.delete(site.filename)
     end


### PR DESCRIPTION
- This previously got the last entry in the table of TNA timestamps when
  it was a plain HTML table. This has been broken since the TNA changed
  their site to be JS-ified and not have a plain list, but several
  dropdowns with list elements that weren't predictable
  (http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/government/organisations/prime-ministers-office-10-downing-street,
  for example).
- Now we get around this by using the latest crawl, identified with `+`
  in the URL, and scraping and parsing the "Latest" link (which that `+`
  page is anyway) to find the timestamp. (For some reason, with `.css`
  instead of `.xpath`, it wouldn't get the Latest link but
  the `Show all` link, despite the same structure.)