### PR TITLE
Add competition and adventcalendar bis domains

### DIFF
--- a/data/transition-sites/bis_advent_calendar.yml
+++ b/data/transition-sites/bis_advent_calendar.yml
@@ -1,0 +1,8 @@
+---
+site: bis_advent_calendar
+whitehall_slug: department-for-business-innovation-skills
+homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+tna_timestamp: 20160118143136
+host: www.adventcalendar.greatbusiness.gov.uk
+homepage_furl: www.gov.uk/bis
+global: =410

--- a/data/transition-sites/bis_competition.yml
+++ b/data/transition-sites/bis_competition.yml
@@ -1,0 +1,8 @@
+---
+site: bis_competition
+whitehall_slug: department-for-business-innovation-skills
+homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+tna_timestamp: 20151216143105
+host: www.competition.greatbusiness.gov.uk
+homepage_furl: www.gov.uk/bis
+global: =410


### PR DESCRIPTION
Add competition and advent_calendar subdomains to BIS

[Trello card](https://trello.com/c/iN9aUzOu/413-add-2-greatbusiness-gov-uk-sub-domains-to-the-transition-tool#)