### PR TITLE
Add significant query params for local.direct.gov.uk

### DIFF
--- a/data/transition-sites/directgov_local.yml
+++ b/data/transition-sites/directgov_local.yml
@@ -6,3 +6,4 @@ tna_timestamp: 20140727120113
 host: local.direct.gov.uk
 aliases: 
 - maps.direct.gov.uk
+options: --query-string lgsl:datatype:ref

--- a/data/transition-sites/directgov_local.yml
+++ b/data/transition-sites/directgov_local.yml
@@ -4,6 +4,6 @@ whitehall_slug: government-digital-service
 homepage: https://www.gov.uk/government/organisations/government-digital-service
 tna_timestamp: 20140727120113
 host: local.direct.gov.uk
-aliases: 
+aliases:
 - maps.direct.gov.uk
 options: --query-string lgsl:datatype:ref


### PR DESCRIPTION
We want to be able to redirect users to the relevant local transaction or other content on GOV.UK based on the LGSL or slug for each dataset.

- `lgsl`: used on various paths under `/LDGRedirect`:
    - `/LDGRedirect/MapLocationSearch.do`
    - `/LDGRedirect/Start.do`
    - `/LDGRedirect/index.jsp`
    - `/LDGRedirect/LocationSearch.do`
    - ...and a very few directly on `/LDGRedirect/`

- `datatype`: eg `/LDGRedirect/MapDetailAction.do?datatype=passportofficesregional` (can't see it used on any other paths)

- `ref`: eg `/LDGRedirect/MapAction.do?ref=weddingvenues` - also used on `/LDGRedirect/Policing.do?ref=neighbourhood` but only with one value there

We have decided to not add `type` as significant. It's used with `single` or `multiple` as the value; with `single` it returns a redirect to a link in the dataset instead of showing a page with the link on it. If we need to provide this behaviour in future, the data to do it wouldn't be available to Bouncer, so we would instead need to add a rule to Bouncer such that when `type=single` is present, it redirects to another application, preserving the rest of the query parameters. We don't have strong evidence of a user need for this now, so aren't doing it.