### PR TITLE
[directgov_local] Update homepage and set homepage_title

### DIFF
--- a/data/transition-sites/directgov_local.yml
+++ b/data/transition-sites/directgov_local.yml
@@ -1,9 +1,10 @@
 ---
 site: directgov_local
 whitehall_slug: government-digital-service
-homepage: https://www.gov.uk/government/organisations/government-digital-service
+homepage: https://www.gov.uk/find-your-local-council
 tna_timestamp: 20140727120113
 host: local.direct.gov.uk
 aliases:
 - maps.direct.gov.uk
 options: --query-string lgsl:datatype:ref
+homepage_title: 'local government services and information'


### PR DESCRIPTION
This site hosts a wide variety of services and it's hard to come up with a
description which works well for both the old site and the new `homepage`.
We're redirecting the vast majority of pages which users ever see so very few
people will see an archive page, and if they do it would probably be on a page
which GOV.UK doesn't have any related content for, so there isn't much point
in sending them to the GOV.UK homepage. Linking to find your local council
seems more appropriate in those cases, although it still isn't great.

The `homepage_title` is adapted from the [one for alpha.gov.uk](https://github.com/alphagov/transition-config/blob/master/data/transition-sites/alphagov.yml). Again, words are
hard.