### PR TITLE
Configure the DFID R4D site in Transition

### DIFF
--- a/data/transition-sites/dfid_r4d.yml
+++ b/data/transition-sites/dfid_r4d.yml
@@ -1,0 +1,7 @@
+---
+site: dfid_r4d
+whitehall_slug: department-for-international-development
+homepage: https://gov.uk/dfid-research-outputs
+homepage_title: 'Research for Development Outputs'
+tna_timestamp: 20140711135552
+host: r4d.dfid.gov.uk


### PR DESCRIPTION
- This site has fallback rules in Bouncer
  (https://github.com/alphagov/bouncer/blob/master/lib/bouncer/fallback_rules.rb#L17-L21),
  but mappings will override those and we can remove them at a later
  date.

(On behalf of @rgarner.)