### PR TITLE
Fix homepage for r4d.dfid.gov.uk

### DIFF
--- a/data/transition-sites/dfid_r4d.yml
+++ b/data/transition-sites/dfid_r4d.yml
@@ -1,7 +1,7 @@
 ---
 site: dfid_r4d
 whitehall_slug: department-for-international-development
-homepage: https://gov.uk/dfid-research-outputs
+homepage: https://www.gov.uk/dfid-research-outputs
 homepage_title: 'Research for Development Outputs'
 tna_timestamp: 20160323135854
 host: r4d.dfid.gov.uk


### PR DESCRIPTION
The homepage was lacking a `www.` in front, meaning
the destination domain (`gov.uk`) wasn't actually in the
whitelist. This is causing 501 errors in production as the
domain is being transitioned.

/cc @jennyd 