### PR TITLE
Update URL for Find your local council on 2 sites

### DIFF
--- a/data/transition-sites/directgov_local.yml
+++ b/data/transition-sites/directgov_local.yml
@@ -1,7 +1,7 @@
 ---
 site: directgov_local
 whitehall_slug: government-digital-service
-homepage: https://www.gov.uk/find-your-local-council
+homepage: https://www.gov.uk/find-local-council
 tna_timestamp: 20140727120113
 host: local.direct.gov.uk
 aliases:

--- a/data/transition-sites/directgov_mycouncil.yml
+++ b/data/transition-sites/directgov_mycouncil.yml
@@ -4,5 +4,5 @@ whitehall_slug: government-digital-service
 homepage: https://www.gov.uk/government/organisations/government-digital-service
 tna_timestamp: 20130221165347
 host: mycouncil.direct.gov.uk
-global: =301 https://www.gov.uk/find-your-local-council
+global: =301 https://www.gov.uk/find-local-council
 css: directgov


### PR DESCRIPTION
We've replaced the old start page with new functionality on GOV.UK which we
should use instead. The old URL redirects to this new one anyway, but it's
nicer to avoid the extra redirect.