### PR TITLE
Add Barrier Busting Communities site

### DIFF
--- a/data/transition-sites/dclg_bb.yml
+++ b/data/transition-sites/dclg_bb.yml
@@ -1,0 +1,9 @@
+---
+site: dclg_bb
+whitehall_slug: department-for-communities-and-local-government
+homepage: https://www.gov.uk/government/publications/sustainable-communities-act-and-barrier-busting
+tna_timestamp: 20150310032258
+host: barrierbusting.communities.gov.uk
+aliases:
+- www.barrierbusting.communities.gov.uk
+global: =301 https://www.gov.uk/government/publications/sustainable-communities-act-and-barrier-busting


### PR DESCRIPTION
Added to transition tool without global redirect so that they can add their own redirects in
when the new site is published.

[Trello card](https://trello.com/c/xSqTX6fe/487-dclg-barrier-busting-transition)
[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/1398310)