### PR TITLE
[phe_lho] Update timestamp and add non-www alias

### DIFF
--- a/data/transition-sites/phe_lho.yml
+++ b/data/transition-sites/phe_lho.yml
@@ -2,7 +2,9 @@
 site: phe_lho
 whitehall_slug: public-health-england
 homepage: https://www.gov.uk/government/organisations/public-health-england
-tna_timestamp: 20160105090914
+tna_timestamp: 20160919145853
 host: www.lho.org.uk
 homepage_furl: www.gov.uk/phe
 global: =410
+aliases:
+- lho.org.uk


### PR DESCRIPTION
This new TNA crawl will be published on 30/09/2016 (this Friday), which is also when the
site should transition. PHE have asked us to add the non-www domain as an
alias too.

See recent replies on https://govuk.zendesk.com/agent/tickets/1420643