### PR TITLE
[DO NOT MERGE] Add non-www alias

### DIFF
--- a/data/transition-sites/phe_sepho.yml
+++ b/data/transition-sites/phe_sepho.yml
@@ -6,3 +6,5 @@ tna_timestamp: 20160701122411
 host: www.sepho.org.uk
 homepage_furl: www.gov.uk/phe
 global: =410
+aliases:
+- sepho.org.uk


### PR DESCRIPTION
We think they're probably going to want this as well as the A record is set up to point to the same IP, even if there isn't anything listening for that hostname at the origin.

I've asked the question on https://govuk.zendesk.com/agent/tickets/1430040 so we're going to give Paul a chance to decide before taking action