### PR TITLE
Add aliases to number10 site

### DIFF
--- a/data/transition-sites/number10.yml
+++ b/data/transition-sites/number10.yml
@@ -6,8 +6,3 @@ tna_timestamp: 20130109092234
 homepage_furl: www.gov.uk/number10
 homepage: https://www.gov.uk/government/organisations/prime-ministers-office-10-downing-street
 css: number10
-locations:
-- path: ^/news/?([_0-9a-zA-Z-]+)?/([0-9]+)/([0-9]+)/(.*)-([0-9]+)$
-  operation: ~*
-  status: 301
-  new_url: http://www.number10.gov.uk/news/$4

--- a/data/transition-sites/number10.yml
+++ b/data/transition-sites/number10.yml
@@ -6,3 +6,9 @@ tna_timestamp: 20130109092234
 homepage_furl: www.gov.uk/number10
 homepage: https://www.gov.uk/government/organisations/prime-ministers-office-10-downing-street
 css: number10
+aliases:
+- number10.gov.uk
+- pm.gov.uk
+- www.pm.gov.uk
+- number-10.gov.uk
+- www.number-10.gov.uk

--- a/tests/fixtures/sites/paths.yml
+++ b/tests/fixtures/sites/paths.yml
@@ -3,7 +3,3 @@ site: paths
 host: paths.local
 aliases:
     - alias1.paths.local
-locations:
-    - path: /
-      new: http://www.example.com/foo/bar
-      status: 301


### PR DESCRIPTION
From looking at the TNA crawls of these domains, they all look like aliases of www.number10.gov.uk. There's a rule in Bouncer for this site which will need these hostnames adding in order for it to take effect for them, but it's better to get these aliases added first since [these domains aren't currently working at all](https://twitter.com/gdsteam/status/785863296767430657).

Also clean up some old unused config.