### PR TITLE
Change BIS organisation slugs to BEIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Substitute each argument and then run the following rake task (you may need to r
   <owning_organisation_abbreviation>_<abbreviated_site_name>
 ```
 
-Example for the "SPIRE Export Control" site which is owned by the Department for Business, Innovation and Skills:
+Example for the "Obesity West Midlands" site which is owned by Public Health England:
 ```
-  bis_spire
+  phe_obesitywm
 ```
 
 The ``abbr`` is used in the URL for the site in the transition app. It is used as the primary key for a site and so shouldn't be changed once imported into the transition app, or a duplicate site will be created.
@@ -113,7 +113,7 @@ We continue to serve some pages and assets for Directgov and BusinessLink sites.
 stored in GitHub and served by Bouncer's nginx configuration. See:
 * [assets-directgov](https://github.com/alphagov/assets-directgov)
 * [assets-businesslink](https://github.com/alphagov/assets-businesslink)
-* [Bouncer's nginx configuration](https://github.gds/gds/puppet/blob/master/modules/govuk/manifests/apps/bouncer.pp#L28-L119)
+* [Bouncer's nginx configuration](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/apps/bouncer.pp#L28-L119)
 
 Bouncer's nginx configuration also includes a small number of redirects and
 other behaviours not possible with mappings.

--- a/data/transition-sites/berr_iat.yml
+++ b/data/transition-sites/berr_iat.yml
@@ -2,6 +2,7 @@
 site: berr_iat
 whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage_furl: www.gov.uk/beis
 tna_timestamp: 20100304111456
 host: iatraining.berr.gov.uk
 global: =410

--- a/data/transition-sites/berr_iat.yml
+++ b/data/transition-sites/berr_iat.yml
@@ -1,7 +1,7 @@
 ---
 site: berr_iat
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20100304111456
 host: iatraining.berr.gov.uk
 global: =410

--- a/data/transition-sites/berr_scmtraining.yml
+++ b/data/transition-sites/berr_scmtraining.yml
@@ -1,8 +1,8 @@
 ---
 site: berr_scmtraining
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20090902161817
 host: www.scmtraining.berr.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 global: =410

--- a/data/transition-sites/bis.yml
+++ b/data/transition-sites/bis.yml
@@ -1,10 +1,10 @@
 ---
 site: bis
-whitehall_slug: department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
 host: www.bis.gov.uk
 tna_timestamp: 20121212135622 # Partial: update with care - TNA will have pages from www.gov.uk
-homepage_furl: www.gov.uk/bis
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+homepage_furl: www.gov.uk/beis
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 css: department-for-business-innovation-skills
 aliases:
 - bis.gov.uk

--- a/data/transition-sites/bis.yml
+++ b/data/transition-sites/bis.yml
@@ -5,7 +5,6 @@ host: www.bis.gov.uk
 tna_timestamp: 20121212135622 # Partial: update with care - TNA will have pages from www.gov.uk
 homepage_furl: www.gov.uk/beis
 homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
-css: department-for-business-innovation-skills
 aliases:
 - bis.gov.uk
 - www2.bis.gov.uk

--- a/data/transition-sites/bis_abcalculator.yml
+++ b/data/transition-sites/bis_abcalculator.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_abcalculator
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: abcalculator.bis.gov.uk
 aliases:
 - www.abcalculator.bis.gov.uk
 global: =301 https://www.gov.uk/government/policies/reducing-the-impact-of-regulation-on-business
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis

--- a/data/transition-sites/bis_advent_calendar.yml
+++ b/data/transition-sites/bis_advent_calendar.yml
@@ -1,8 +1,8 @@
 ---
 site: bis_advent_calendar
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20160118143136
 host: www.adventcalendar.greatbusiness.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 global: =410

--- a/data/transition-sites/bis_aebc.yml
+++ b/data/transition-sites/bis_aebc.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_aebc
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20100419143353
 host: www.aebc.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - aebc.gov.uk
 global: =410

--- a/data/transition-sites/bis_archive.yml
+++ b/data/transition-sites/bis_archive.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_archive
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20101012113206
 host: archive.bis.gov.uk
-homepage_furl: www.gov.uk/bis_archive
+homepage_furl: www.gov.uk/beis
 global: =410
 aliases:
 - www.archive.bis.gov.uk

--- a/data/transition-sites/bis_berr.yml
+++ b/data/transition-sites/bis_berr.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_berr
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20090609003228
 host: www.berr.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - berr.gov.uk
 global: =410

--- a/data/transition-sites/bis_betterregulation.yml
+++ b/data/transition-sites/bis_betterregulation.yml
@@ -1,7 +1,7 @@
 ---
 site: bis_betterregulation
 whitehall_slug: department-for-business-energy-and-industrial-strategy
-homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/policies/reducing-the-impact-of-regulation-on-business
 tna_timestamp: 20130420125611
 host: www.betterregulation.gov.uk
 aliases:

--- a/data/transition-sites/bis_betterregulation.yml
+++ b/data/transition-sites/bis_betterregulation.yml
@@ -4,7 +4,6 @@ whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20130420125611
 host: www.betterregulation.gov.uk
-homepage_furl: www.gov.uk/beis
 aliases:
 - betterregulation.gov.uk
 global: =301 https://www.gov.uk/government/policies/reducing-the-impact-of-regulation-on-business

--- a/data/transition-sites/bis_betterregulation.yml
+++ b/data/transition-sites/bis_betterregulation.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_betterregulation
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20130420125611
 host: www.betterregulation.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - betterregulation.gov.uk
 global: =301 https://www.gov.uk/government/policies/reducing-the-impact-of-regulation-on-business

--- a/data/transition-sites/bis_bhc.yml
+++ b/data/transition-sites/bis_bhc.yml
@@ -5,6 +5,5 @@ host: www.britishhallmarkingcouncil.gov.uk
 tna_timestamp: 20100116001507
 homepage_furl: www.gov.uk/british-hallmarking-council
 homepage: https://www.gov.uk/government/organisations/british-hallmarking-council
-css: bis
 global: =301 http://www.bis.gov.uk/britishhallmarkingcouncil
 global_redirect_append_path: true

--- a/data/transition-sites/bis_biy.yml
+++ b/data/transition-sites/bis_biy.yml
@@ -1,7 +1,7 @@
 ---
 site: bis_biy
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20140402165524
 host: businessinyou.bis.gov.uk
 aliases:

--- a/data/transition-sites/bis_blogs.yml
+++ b/data/transition-sites/bis_blogs.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_blogs
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20140703133908
 host: blogs.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.blogs.bis.gov.uk
 extra_organisation_slugs:

--- a/data/transition-sites/bis_bre.yml
+++ b/data/transition-sites/bis_bre.yml
@@ -1,6 +1,6 @@
 ---
 site: bis_bre
-whitehall_slug: department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/policies/reducing-the-impact-of-regulation-on-business
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: bre.bis.gov.uk

--- a/data/transition-sites/bis_choices.yml
+++ b/data/transition-sites/bis_choices.yml
@@ -1,9 +1,9 @@
 ---
 site: bis_choices
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: choices.bis.gov.uk
 aliases:
 - www.choices.bis.gov.uk
-global: =301 https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_cic.yml
+++ b/data/transition-sites/bis_cic.yml
@@ -5,7 +5,6 @@ host: www.cicregulator.gov.uk
 tna_timestamp: 20131003151857
 homepage_furl: www.gov.uk/cic-regulator
 homepage: https://www.gov.uk/government/organisations/office-of-the-regulator-of-community-interest-companies
-css: bis
 aliases:
 - cicregulator.gov.uk
 - www.cicreg.gov.uk

--- a/data/transition-sites/bis_cic.yml
+++ b/data/transition-sites/bis_cic.yml
@@ -12,4 +12,4 @@ aliases:
 - cicreg.gov.uk
 global: =301 https://www.gov.uk/government/organisations/office-of-the-regulator-of-community-interest-companies
 extra_organisation_slugs:
-- department-for-business-innovation-skills
+- department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_competition.yml
+++ b/data/transition-sites/bis_competition.yml
@@ -1,8 +1,8 @@
 ---
 site: bis_competition
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20151216143105
 host: www.competition.greatbusiness.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 global: =410

--- a/data/transition-sites/bis_consultations.yml
+++ b/data/transition-sites/bis_consultations.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_consultations
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: consultations.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.consultations.bis.gov.uk
-global: =301 https://www.gov.uk/government/publications?keywords=&publication_filter_option=consultations&departments%5B%5D=department-for-business-innovation-skills
+global: =301 https://www.gov.uk/government/publications?keywords=&publication_filter_option=consultations&departments%5B%5D=department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_conversation.yml
+++ b/data/transition-sites/bis_conversation.yml
@@ -1,9 +1,9 @@
 ---
 site: bis_conversation
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: conversation.bis.gov.uk
 aliases:
 - www.conversation.bis.gov.uk
-global: =301 https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_csr.yml
+++ b/data/transition-sites/bis_csr.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_csr
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20090217050313
 host: www.csr.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - csr.gov.uk
 global: =301 https://www.gov.uk/government/policies/making-companies-more-accountable-to-shareholders-and-the-public

--- a/data/transition-sites/bis_csr.yml
+++ b/data/transition-sites/bis_csr.yml
@@ -1,10 +1,9 @@
 ---
 site: bis_csr
 whitehall_slug: department-for-business-energy-and-industrial-strategy
-homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/policies/making-companies-more-accountable-to-shareholders-and-the-public
 tna_timestamp: 20090217050313
 host: www.csr.gov.uk
-homepage_furl: www.gov.uk/beis
 aliases:
 - csr.gov.uk
 global: =301 https://www.gov.uk/government/policies/making-companies-more-accountable-to-shareholders-and-the-public

--- a/data/transition-sites/bis_digital.yml
+++ b/data/transition-sites/bis_digital.yml
@@ -1,9 +1,9 @@
 ---
 site: bis_digital
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: digital.bis.gov.uk
 aliases:
 - www.digital.bis.gov.uk
-global: =301 https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_discuss.yml
+++ b/data/transition-sites/bis_discuss.yml
@@ -1,9 +1,9 @@
 ---
 site: bis_discuss
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20140505102421
 host: discuss.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.discuss.bis.gov.uk

--- a/data/transition-sites/bis_dius.yml
+++ b/data/transition-sites/bis_dius.yml
@@ -5,7 +5,6 @@ host: www.dius.gov.uk
 tna_timestamp: 20100222165247
 homepage_furl: www.gov.uk/beis
 homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
-css: department-for-business-energy-and-industrial-strategy
 global: =410
 aliases:
 - dius.gov.uk

--- a/data/transition-sites/bis_dius.yml
+++ b/data/transition-sites/bis_dius.yml
@@ -1,11 +1,11 @@
 ---
 site: bis_dius
-whitehall_slug: department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
 host: www.dius.gov.uk
 tna_timestamp: 20100222165247
-homepage_furl: www.gov.uk/bis
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
-css: department-for-business-innovation-skills
+homepage_furl: www.gov.uk/beis
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+css: department-for-business-energy-and-industrial-strategy
 global: =410
 aliases:
 - dius.gov.uk

--- a/data/transition-sites/bis_diversity.yml
+++ b/data/transition-sites/bis_diversity.yml
@@ -1,11 +1,11 @@
 ---
 site: bis_diversity
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: diversity.bis.gov.uk
 aliases:
 - www.diversity.bis.gov.uk
 - elearning.bis.gov.uk
 - www.elearning.bis.gov.uk
-global: =301 https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_dti.yml
+++ b/data/transition-sites/bis_dti.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_dti
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20070603164510
 host: www.dti.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - dti.gov.uk
 global: =410

--- a/data/transition-sites/bis_ecchk.yml
+++ b/data/transition-sites/bis_ecchk.yml
@@ -2,6 +2,7 @@
 site: bis_ecchk
 whitehall_slug: department-for-international-trade
 homepage: https://www.gov.uk/government/organisations/department-for-international-trade
+homepage_furl: www.gov.uk/dit
 tna_timestamp: 20140320153108
 host: www.ecochecker.bis.gov.uk
 aliases:

--- a/data/transition-sites/bis_ecchk.yml
+++ b/data/transition-sites/bis_ecchk.yml
@@ -1,9 +1,10 @@
 ---
 site: bis_ecchk
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-international-trade
+homepage: https://www.gov.uk/government/organisations/department-for-international-trade
 tna_timestamp: 20140320153108
 host: www.ecochecker.bis.gov.uk
-homepage_furl: www.gov.uk/bis
 aliases:
 - ecochecker.bis.gov.uk
+extra_organisation_slugs:
+- department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_ecdb.yml
+++ b/data/transition-sites/bis_ecdb.yml
@@ -1,11 +1,12 @@
 ---
 site: bis_ecdb
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-international-trade
+homepage: https://www.gov.uk/government/organisations/department-for-international-trade
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: www.exportcontroldb.bis.gov.uk
-homepage_furl: www.gov.uk/bis
 aliases:
 - exportcontroldb.bis.gov.uk
 - exportcontroldbuat.bis.gov.uk
 - www.exportcontroldbuat.bis.gov.uk
+extra_organisation_slugs:
+- department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_ecdb.yml
+++ b/data/transition-sites/bis_ecdb.yml
@@ -2,6 +2,7 @@
 site: bis_ecdb
 whitehall_slug: department-for-international-trade
 homepage: https://www.gov.uk/government/organisations/department-for-international-trade
+homepage_furl: www.gov.uk/dit
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: www.exportcontroldb.bis.gov.uk
 aliases:

--- a/data/transition-sites/bis_enemy.yml
+++ b/data/transition-sites/bis_enemy.yml
@@ -1,7 +1,7 @@
 ---
 site: bis_enemy
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20090506172208
 host: www.enemyproperty.gov.uk
 aliases:

--- a/data/transition-sites/bis_enemy.yml
+++ b/data/transition-sites/bis_enemy.yml
@@ -2,6 +2,7 @@
 site: bis_enemy
 whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage_furl: www.gov.uk/beis
 tna_timestamp: 20090506172208
 host: www.enemyproperty.gov.uk
 aliases:

--- a/data/transition-sites/bis_epcap.yml
+++ b/data/transition-sites/bis_epcap.yml
@@ -1,7 +1,7 @@
 ---
 site: bis_epcap
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - not in TNA
 host: enemyproperty.bis.gov.uk
 aliases:

--- a/data/transition-sites/bis_forms.yml
+++ b/data/transition-sites/bis_forms.yml
@@ -1,9 +1,9 @@
 ---
 site: bis_forms
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: forms.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.forms.bis.gov.uk

--- a/data/transition-sites/bis_ga_businessgrowthservice.yml
+++ b/data/transition-sites/bis_ga_businessgrowthservice.yml
@@ -1,8 +1,8 @@
 ---
 site: bis_ga_businessgrowthservice
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20160105122946
 host: www.ga.businessgrowthservice.greatbusiness.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 global: =410

--- a/data/transition-sites/bis_goforit.yml
+++ b/data/transition-sites/bis_goforit.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_goforit
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: goforit.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.goforit.bis.gov.uk
-global: =301 https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_greatbusiness.yml
+++ b/data/transition-sites/bis_greatbusiness.yml
@@ -1,9 +1,9 @@
 ---
 site: bis_greatbusiness
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20160105122945
 host: www.greatbusiness.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - greatbusiness.gov.uk

--- a/data/transition-sites/bis_gtp.yml
+++ b/data/transition-sites/bis_gtp.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_gtp
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20140105013730
 host: graduatetalentpool.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.graduatetalentpool.bis.gov.uk
 - gvtool.bis.gov.uk

--- a/data/transition-sites/bis_hsctk.yml
+++ b/data/transition-sites/bis_hsctk.yml
@@ -1,9 +1,11 @@
 ---
 site: bis_hsctk
-whitehall_slug: department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/publications/futures-toolkit-for-policy-makers-and-analysts
 tna_timestamp: 20130802230407
 host: hsctoolkit.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.hsctoolkit.bis.gov.uk
+extra_organisation_slugs:
+- government-office-for-science

--- a/data/transition-sites/bis_hsctraining.yml
+++ b/data/transition-sites/bis_hsctraining.yml
@@ -1,9 +1,11 @@
 ---
 site: bis_hsctraining
-whitehall_slug: department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/groups/horizon-scanning-programme-team
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: hsctraininggateway.bis.gov.uk
 aliases:
 - www.hsctraininggateway.bis.gov.uk
 global: =301 https://www.gov.uk/government/groups/horizon-scanning-programme-team
+extra_organisation_slugs:
+- government-office-for-science

--- a/data/transition-sites/bis_iacl.yml
+++ b/data/transition-sites/bis_iacl.yml
@@ -1,6 +1,6 @@
 ---
 site: bis_iacl
-whitehall_slug: department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/consultations/new-challenges-new-chances-next-steps-in-implementing-the-further-education-reform-programme
 tna_timestamp: 20111108170410
 host: iacl.bis.gov.uk

--- a/data/transition-sites/bis_ial.yml
+++ b/data/transition-sites/bis_ial.yml
@@ -2,6 +2,7 @@
 site: bis_ial
 whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage_furl: www.gov.uk/beis
 tna_timestamp: 20130314024249
 host: ialibrary.bis.gov.uk
 aliases:

--- a/data/transition-sites/bis_ial.yml
+++ b/data/transition-sites/bis_ial.yml
@@ -1,7 +1,7 @@
 ---
 site: bis_ial
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20130314024249
 host: ialibrary.bis.gov.uk
 aliases:

--- a/data/transition-sites/bis_iat.yml
+++ b/data/transition-sites/bis_iat.yml
@@ -1,6 +1,6 @@
 ---
 site: bis_iat
-whitehall_slug: department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/collections/impact-assessments-guidance-for-government-departments
 tna_timestamp: 20100304111456
 host: iatraining.bis.gov.uk

--- a/data/transition-sites/bis_ilb.yml
+++ b/data/transition-sites/bis_ilb.yml
@@ -2,6 +2,7 @@
 site: bis_ilb
 whitehall_slug: department-for-international-trade
 homepage: https://www.gov.uk/government/organisations/department-for-international-trade
+homepage_furl: www.gov.uk/dit
 tna_timestamp: 20131222235230
 host: ilb.bis.gov.uk
 aliases:

--- a/data/transition-sites/bis_ilb.yml
+++ b/data/transition-sites/bis_ilb.yml
@@ -1,7 +1,7 @@
 ---
 site: bis_ilb
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-international-trade
+homepage: https://www.gov.uk/government/organisations/department-for-international-trade
 tna_timestamp: 20131222235230
 host: ilb.bis.gov.uk
 aliases:
@@ -9,3 +9,5 @@ aliases:
 - ilbuat.bis.gov.uk
 - www.ilbuat.bis.gov.uk
 global: =410
+extra_organisation_slugs:
+- department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_interactive.yml
+++ b/data/transition-sites/bis_interactive.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_interactive
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20120708131021
 host: interactive.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.interactive.bis.gov.uk
 - interactive2.bis.gov.uk

--- a/data/transition-sites/bis_library.yml
+++ b/data/transition-sites/bis_library.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_library
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: library.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.library.bis.gov.uk
-global: =301 https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_lowpay.yml
+++ b/data/transition-sites/bis_lowpay.yml
@@ -5,7 +5,6 @@ host: www.lowpay.gov.uk
 tna_timestamp: 20130626202215
 homepage_furl: www.gov.uk/lpc
 homepage: https://www.gov.uk/government/organisations/low-pay-commission
-css: department-for-business-innovation-skills
 aliases:
 - www2.lowpay.gov.uk
 - search.lowpay.gov.uk

--- a/data/transition-sites/bis_mas.yml
+++ b/data/transition-sites/bis_mas.yml
@@ -1,6 +1,6 @@
 ---
 site: bis_mas
-whitehall_slug: department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/business-finance-support-finder
 homepage_title: 'business support finder'
 tna_timestamp: 20140320153140

--- a/data/transition-sites/bis_mas2.yml
+++ b/data/transition-sites/bis_mas2.yml
@@ -1,6 +1,6 @@
 ---
 site: bis_mas2
-whitehall_slug: department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage_title: 'business support finder'
 homepage: https://www.gov.uk/business-finance-support-finder
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA

--- a/data/transition-sites/bis_mas_businessgrowthservice.yml
+++ b/data/transition-sites/bis_mas_businessgrowthservice.yml
@@ -1,6 +1,6 @@
 ---
 site: bis_mas_businessgrowthservice
-whitehall_slug: department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/business-finance-support-finder
 homepage_title: 'business support finder'
 tna_timestamp: 20160105122945

--- a/data/transition-sites/bis_mentorme.yml
+++ b/data/transition-sites/bis_mentorme.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_mentorme
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: www.mentorme.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - mentorme.bis.gov.uk
-global: =301 https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_news.yml
+++ b/data/transition-sites/bis_news.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_news
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20140311021924
 host: news.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.news.bis.gov.uk
-global: =301 https://www.gov.uk/government/announcements?departments%5B%5D=department-for-business-innovation-skills
+global: =301 https://www.gov.uk/government/announcements?departments%5B%5D=department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_nlss.yml
+++ b/data/transition-sites/bis_nlss.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_nlss
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: nlss.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.nlss.bis.gov.uk
 global: =301 https://www.gov.uk/government/collections/fe-choices-information-for-providers

--- a/data/transition-sites/bis_ome.yml
+++ b/data/transition-sites/bis_ome.yml
@@ -6,4 +6,3 @@ tna_timestamp: 20130106083031
 homepage_furl: www.gov.uk/ome
 homepage: https://www.gov.uk/government/organisations/office-of-manpower-economics
 options: --query-string documentuid:articleuid
-css: department-for-business-innovation-skills

--- a/data/transition-sites/bis_pa.yml
+++ b/data/transition-sites/bis_pa.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_pa
-whitehall_slug: department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/organisations/better-regulation-delivery-office
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: primaryauthority.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.primaryauthority.bis.gov.uk
 global: =301 https://www.gov.uk/government/organisations/better-regulation-delivery-office

--- a/data/transition-sites/bis_pa.yml
+++ b/data/transition-sites/bis_pa.yml
@@ -4,7 +4,6 @@ whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/organisations/better-regulation-delivery-office
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: primaryauthority.bis.gov.uk
-homepage_furl: www.gov.uk/beis
 aliases:
 - www.primaryauthority.bis.gov.uk
 global: =301 https://www.gov.uk/government/organisations/better-regulation-delivery-office

--- a/data/transition-sites/bis_psi.yml
+++ b/data/transition-sites/bis_psi.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_psi
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20121126080644
 host: publicsectorinnovation.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.publicsectorinnovation.bis.gov.uk
-global: =301 https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_publications.yml
+++ b/data/transition-sites/bis_publications.yml
@@ -1,10 +1,9 @@
 ---
 site: bis_publications
 whitehall_slug: department-for-business-energy-and-industrial-strategy
-homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/publications?departments%5B%5D=department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: publications.bis.gov.uk
-homepage_furl: www.gov.uk/beis
 aliases:
 - www.publications.bis.gov.uk
 global: =301 https://www.gov.uk/government/publications?departments%5B%5D=department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_publications.yml
+++ b/data/transition-sites/bis_publications.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_publications
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: publications.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.publications.bis.gov.uk
-global: =301 https://www.gov.uk/government/publications?departments%5B%5D=department-for-business-innovation-skills
+global: =301 https://www.gov.uk/government/publications?departments%5B%5D=department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_qa.yml
+++ b/data/transition-sites/bis_qa.yml
@@ -1,6 +1,6 @@
 ---
 site: bis_qa
-whitehall_slug: department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage_title: 'Queens Awards'
 homepage: https://www.gov.uk/queens-awards-for-enterprise
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA

--- a/data/transition-sites/bis_queensawards.yml
+++ b/data/transition-sites/bis_queensawards.yml
@@ -1,6 +1,6 @@
 ---
 site: bis_queensawards
-whitehall_slug: department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage_title: 'Queens Awards'
 homepage: https://www.gov.uk/queens-awards-for-enterprise
 tna_timestamp: 20140304164435

--- a/data/transition-sites/bis_rc.yml
+++ b/data/transition-sites/bis_rc.yml
@@ -1,10 +1,9 @@
 ---
 site: bis_rc
 whitehall_slug: department-for-business-energy-and-industrial-strategy
-homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/publications?departments[]=department-for-business-energy-and-industrial-strategy&publication_filter_option=consultations
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: renewableconsultation.bis.gov.uk
-homepage_furl: www.gov.uk/beis
 aliases:
 - www.renewableconsultation.bis.gov.uk
 global: =301 https://www.gov.uk/government/publications?departments[]=department-for-business-energy-and-industrial-strategy&publication_filter_option=consultations

--- a/data/transition-sites/bis_rc.yml
+++ b/data/transition-sites/bis_rc.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_rc
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: renewableconsultation.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.renewableconsultation.bis.gov.uk
-global: =301 https://www.gov.uk/government/publications?departments[]=department-for-business-innovation-skills&publication_filter_option=consultations
+global: =301 https://www.gov.uk/government/publications?departments[]=department-for-business-energy-and-industrial-strategy&publication_filter_option=consultations

--- a/data/transition-sites/bis_rct.yml
+++ b/data/transition-sites/bis_rct.yml
@@ -1,11 +1,11 @@
 ---
 site: bis_rct
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: rct.bis.gov.uk
-homepage_furl: www.gov.uk/bis
-global: =301 https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+homepage_furl: www.gov.uk/beis
+global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 aliases:
 - ci.rct.bis.gov.uk
 - dev.rct.bis.gov.uk

--- a/data/transition-sites/bis_rdna.yml
+++ b/data/transition-sites/bis_rdna.yml
@@ -4,6 +4,5 @@ whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20140320200621
 host: rdna-tool.bis.gov.uk
-homepage_furl: www.gov.uk/beis
 aliases:
 - www.rdna-tool.bis.gov.uk

--- a/data/transition-sites/bis_rdna.yml
+++ b/data/transition-sites/bis_rdna.yml
@@ -1,7 +1,7 @@
 ---
 site: bis_rdna
 whitehall_slug: department-for-business-energy-and-industrial-strategy
-homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/regulatory-delivery
 tna_timestamp: 20140320200621
 host: rdna-tool.bis.gov.uk
 aliases:

--- a/data/transition-sites/bis_rdna.yml
+++ b/data/transition-sites/bis_rdna.yml
@@ -1,9 +1,9 @@
 ---
 site: bis_rdna
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20140320200621
 host: rdna-tool.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.rdna-tool.bis.gov.uk

--- a/data/transition-sites/bis_rpc.yml
+++ b/data/transition-sites/bis_rpc.yml
@@ -6,4 +6,3 @@ tna_timestamp: 20130403085727
 homepage_furl: www.gov.uk/rpc
 homepage: https://www.gov.uk/government/organisations/regulatory-policy-committee
 options: --query-string attachment_id
-css: department-for-business-innovation-skills

--- a/data/transition-sites/bis_sandbox.yml
+++ b/data/transition-sites/bis_sandbox.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_sandbox
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20120809151845
 host: sandbox.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.sandbox.bis.gov.uk
 global: =410

--- a/data/transition-sites/bis_sas.yml
+++ b/data/transition-sites/bis_sas.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_sas
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20121205091100
 host: scienceandsociety.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.scienceandsociety.bis.gov.uk
 global: =410

--- a/data/transition-sites/bis_scmtraining.yml
+++ b/data/transition-sites/bis_scmtraining.yml
@@ -1,8 +1,8 @@
 ---
 site: bis_scmtraining
-whitehall_slug: department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/policies/reducing-the-impact-of-regulation-on-business/supporting-pages/assessing-the-impact-of-new-regulation
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: www.scmtraining.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 global: =301 https://www.gov.uk/government/policies/reducing-the-impact-of-regulation-on-business/supporting-pages/assessing-the-impact-of-new-regulation

--- a/data/transition-sites/bis_search.yml
+++ b/data/transition-sites/bis_search.yml
@@ -1,14 +1,14 @@
 ---
 site: bis_search
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: search.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - search3.bis.gov.uk
 - search4.bis.gov.uk
 - www.search.bis.gov.uk
 - www.search3.bis.gov.uk
 - www.search4.bis.gov.uk
-global: =301 https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_security.yml
+++ b/data/transition-sites/bis_security.yml
@@ -1,10 +1,12 @@
 ---
 site: bis_security
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-culture-media-sport
+homepage: https://www.gov.uk/government/organisations/department-for-culture-media-sport
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: www.securityhealthcheck.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/dcms
 global: =301 https://www.gov.uk/government/policies/keeping-the-uk-safe-in-cyberspace
 aliases:
 - securityhealthcheck.bis.gov.uk
+extra_organisation_slugs:
+- department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_security.yml
+++ b/data/transition-sites/bis_security.yml
@@ -1,10 +1,9 @@
 ---
 site: bis_security
 whitehall_slug: department-for-culture-media-sport
-homepage: https://www.gov.uk/government/organisations/department-for-culture-media-sport
+homepage: https://www.gov.uk/government/policies/keeping-the-uk-safe-in-cyberspace
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: www.securityhealthcheck.bis.gov.uk
-homepage_furl: www.gov.uk/dcms
 global: =301 https://www.gov.uk/government/policies/keeping-the-uk-safe-in-cyberspace
 aliases:
 - securityhealthcheck.bis.gov.uk

--- a/data/transition-sites/bis_sigmascan.yml
+++ b/data/transition-sites/bis_sigmascan.yml
@@ -6,5 +6,5 @@ homepage: https://www.gov.uk/government/groups/horizon-scanning-programme-team
 tna_timestamp: 20201010101010 # Plug - site not in TNA
 host: www.sigmascan.org
 extra_organisation_slugs:
-- department-for-business-innovation-skills
+- department-for-business-energy-and-industrial-strategy
 global: =301 https://www.gov.uk/government/groups/horizon-scanning-programme-team

--- a/data/transition-sites/bis_spire.yml
+++ b/data/transition-sites/bis_spire.yml
@@ -1,8 +1,9 @@
 ---
 site: bis_spire
-whitehall_slug: department-for-business-innovation-skills
+whitehall_slug: department-for-international-trade
 homepage_title: 'SPIRE Export Control'
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+homepage: https://www.gov.uk/government/organisations/department-for-international-trade
 tna_timestamp: 20121126074457
 host: www.spire.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+extra_organisation_slugs:
+- department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_spire.yml
+++ b/data/transition-sites/bis_spire.yml
@@ -3,6 +3,7 @@ site: bis_spire
 whitehall_slug: department-for-international-trade
 homepage_title: 'SPIRE Export Control'
 homepage: https://www.gov.uk/government/organisations/department-for-international-trade
+homepage_furl: www.gov.uk/dit
 tna_timestamp: 20121126074457
 host: www.spire.bis.gov.uk
 extra_organisation_slugs:

--- a/data/transition-sites/bis_stats.yml
+++ b/data/transition-sites/bis_stats.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_stats
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills/about/statistics
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy/about/statistics
 tna_timestamp: 20121206072905
 host: stats.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.stats1.bis.gov.uk
 - www.stats2.bis.gov.uk
@@ -12,4 +12,4 @@ aliases:
 - stats2.bis.gov.uk
 - aalookup.bis.gov.uk
 - www.aalookup.bis.gov.uk
-global: =301 https://www.gov.uk/government/organisations/department-for-business-innovation-skills/about/statistics
+global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy/about/statistics

--- a/data/transition-sites/bis_sts.yml
+++ b/data/transition-sites/bis_sts.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_sts
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: sts.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.sts.bis.gov.uk
-global: =301 https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_talk.yml
+++ b/data/transition-sites/bis_talk.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_talk
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: talk.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.talk.bis.gov.uk
-global: =301 https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/bis_ukaea.yml
+++ b/data/transition-sites/bis_ukaea.yml
@@ -6,4 +6,3 @@ tna_timestamp: 20130105231830
 homepage_furl: www.gov.uk/ukaea
 homepage: https://www.gov.uk/government/organisations/uk-atomic-energy-authority
 options:
-css: department-for-business-innovation-skills

--- a/data/transition-sites/bis_vapp.yml
+++ b/data/transition-sites/bis_vapp.yml
@@ -1,10 +1,10 @@
 ---
 site: bis_vapp
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: vapp.bis.gov.uk
-homepage_furl: www.gov.uk/bis
+homepage_furl: www.gov.uk/beis
 aliases:
 - www.vapp.bis.gov.uk
-global: =301 https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy

--- a/data/transition-sites/decc.yml
+++ b/data/transition-sites/decc.yml
@@ -6,4 +6,3 @@ host: www.decc.gov.uk
 tna_timestamp: 20121217150421
 homepage_furl: www.gov.uk/beis
 options: --query-string filepath
-css: department-of-energy-climate-change

--- a/data/transition-sites/decc.yml
+++ b/data/transition-sites/decc.yml
@@ -1,9 +1,9 @@
 ---
 site: decc
-whitehall_slug: department-of-energy-climate-change
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 host: www.decc.gov.uk
 tna_timestamp: 20121217150421
-homepage_furl: www.gov.uk/decc
-homepage: https://www.gov.uk/government/organisations/department-of-energy-climate-change
+homepage_furl: www.gov.uk/beis
 options: --query-string filepath
 css: department-of-energy-climate-change

--- a/data/transition-sites/decc_blog.yml
+++ b/data/transition-sites/decc_blog.yml
@@ -1,8 +1,8 @@
 ---
 site: decc_blog
-whitehall_slug: department-of-energy-climate-change
-homepage: https://decc.blog.gov.uk
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20140403094322
 host: blog.decc.gov.uk
-homepage_furl: www.gov.uk/decc
+homepage_furl: www.gov.uk/beis
 options: --query-string p:page_id

--- a/data/transition-sites/decc_ceo.yml
+++ b/data/transition-sites/decc_ceo.yml
@@ -1,8 +1,8 @@
 ---
 site: decc_ceo
-whitehall_slug: department-of-energy-climate-change
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 host: ceo.decc.gov.uk
 tna_timestamp: 20121220093401
-homepage_furl: www.gov.uk/decc
-homepage: https://www.gov.uk/community-energy
+homepage_furl: www.gov.uk/beis
 css: department-of-energy-climate-change

--- a/data/transition-sites/decc_ceo.yml
+++ b/data/transition-sites/decc_ceo.yml
@@ -5,4 +5,3 @@ homepage: https://www.gov.uk/government/organisations/department-for-business-en
 host: ceo.decc.gov.uk
 tna_timestamp: 20121220093401
 homepage_furl: www.gov.uk/beis
-css: department-of-energy-climate-change

--- a/data/transition-sites/decc_ceo.yml
+++ b/data/transition-sites/decc_ceo.yml
@@ -4,4 +4,3 @@ whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 host: ceo.decc.gov.uk
 tna_timestamp: 20121220093401
-homepage_furl: www.gov.uk/beis

--- a/data/transition-sites/decc_ceo.yml
+++ b/data/transition-sites/decc_ceo.yml
@@ -1,6 +1,6 @@
 ---
 site: decc_ceo
 whitehall_slug: department-for-business-energy-and-industrial-strategy
-homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/community-energy
 host: ceo.decc.gov.uk
 tna_timestamp: 20121220093401

--- a/data/transition-sites/decc_chp.yml
+++ b/data/transition-sites/decc_chp.yml
@@ -2,5 +2,6 @@
 site: decc_chp
 whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage_furl: www.gov.uk/beis
 tna_timestamp: 20140403123255
 host: chp.decc.gov.uk

--- a/data/transition-sites/decc_chp.yml
+++ b/data/transition-sites/decc_chp.yml
@@ -1,6 +1,6 @@
 ---
 site: decc_chp
-whitehall_slug: department-of-energy-climate-change
-homepage: https://www.gov.uk/combined-heat-and-power
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20140403123255
 host: chp.decc.gov.uk

--- a/data/transition-sites/decc_chp.yml
+++ b/data/transition-sites/decc_chp.yml
@@ -1,7 +1,6 @@
 ---
 site: decc_chp
 whitehall_slug: department-for-business-energy-and-industrial-strategy
-homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
-homepage_furl: www.gov.uk/beis
+homepage: https://www.gov.uk/guidance/combined-heat-and-power
 tna_timestamp: 20140403123255
 host: chp.decc.gov.uk

--- a/data/transition-sites/decc_chpqa.yml
+++ b/data/transition-sites/decc_chpqa.yml
@@ -2,5 +2,6 @@
 site: decc_chpqa
 whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage_furl: www.gov.uk/beis
 tna_timestamp: 20140403123232
 host: chpqa.decc.gov.uk

--- a/data/transition-sites/decc_chpqa.yml
+++ b/data/transition-sites/decc_chpqa.yml
@@ -1,6 +1,6 @@
 ---
 site: decc_chpqa
-whitehall_slug: department-of-energy-climate-change
-homepage: https://www.gov.uk/combined-heat-power-quality-assurance-programme
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20140403123232
 host: chpqa.decc.gov.uk

--- a/data/transition-sites/decc_chpqa.yml
+++ b/data/transition-sites/decc_chpqa.yml
@@ -1,7 +1,6 @@
 ---
 site: decc_chpqa
 whitehall_slug: department-for-business-energy-and-industrial-strategy
-homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
-homepage_furl: www.gov.uk/beis
+homepage: https://www.gov.uk/guidance/combined-heat-power-quality-assurance-programme
 tna_timestamp: 20140403123232
 host: chpqa.decc.gov.uk

--- a/data/transition-sites/decc_coal.yml
+++ b/data/transition-sites/decc_coal.yml
@@ -5,7 +5,6 @@ host: coal.decc.gov.uk
 tna_timestamp: 20140721140515
 homepage_furl: www.gov.uk/decc
 homepage: https://www.gov.uk/government/organisations/the-coal-authority
-css: department-of-energy-climate-change
 aliases:
 - www.coal.decc.gov.uk
 - www.coal.gov.uk

--- a/data/transition-sites/decc_corwm.yml
+++ b/data/transition-sites/decc_corwm.yml
@@ -2,6 +2,6 @@
 site: decc_corwm
 whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage_furl: www.gov.uk/corwm
 host: corwm.decc.gov.uk
 tna_timestamp: 20130503173700
-homepage_furl: www.gov.uk/beis

--- a/data/transition-sites/decc_corwm.yml
+++ b/data/transition-sites/decc_corwm.yml
@@ -5,4 +5,3 @@ homepage: https://www.gov.uk/government/organisations/department-for-business-en
 host: corwm.decc.gov.uk
 tna_timestamp: 20130503173700
 homepage_furl: www.gov.uk/beis
-css: department-of-energy-climate-change

--- a/data/transition-sites/decc_corwm.yml
+++ b/data/transition-sites/decc_corwm.yml
@@ -1,7 +1,7 @@
 ---
 site: decc_corwm
 whitehall_slug: department-for-business-energy-and-industrial-strategy
-homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/committee-on-radioactive-waste-management
 homepage_furl: www.gov.uk/corwm
 host: corwm.decc.gov.uk
 tna_timestamp: 20130503173700

--- a/data/transition-sites/decc_corwm.yml
+++ b/data/transition-sites/decc_corwm.yml
@@ -1,8 +1,8 @@
 ---
 site: decc_corwm
-whitehall_slug: department-of-energy-climate-change
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 host: corwm.decc.gov.uk
 tna_timestamp: 20130503173700
-homepage_furl: www.gov.uk/corwm
-homepage: https://www.gov.uk/government/organisations/committee-on-radioactive-waste-management
+homepage_furl: www.gov.uk/beis
 css: department-of-energy-climate-change

--- a/data/transition-sites/decc_etl.yml
+++ b/data/transition-sites/decc_etl.yml
@@ -4,7 +4,6 @@ whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20141002124937
 host: etl.decc.gov.uk
-homepage_furl: www.gov.uk/beis
 options: --query-string prod_id:sub_tech_id
 aliases:
 - www.etl.decc.gov.uk

--- a/data/transition-sites/decc_etl.yml
+++ b/data/transition-sites/decc_etl.yml
@@ -1,10 +1,10 @@
 ---
 site: decc_etl
-whitehall_slug: department-of-energy-climate-change
-homepage: https://www.gov.uk/energy-technology-list
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20141002124937
 host: etl.decc.gov.uk
-homepage_furl: www.gov.uk/etl
+homepage_furl: www.gov.uk/beis
 options: --query-string prod_id:sub_tech_id
 aliases:
 - www.etl.decc.gov.uk

--- a/data/transition-sites/decc_etl.yml
+++ b/data/transition-sites/decc_etl.yml
@@ -1,7 +1,7 @@
 ---
 site: decc_etl
 whitehall_slug: department-for-business-energy-and-industrial-strategy
-homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/guidance/energy-technology-list
 tna_timestamp: 20141002124937
 host: etl.decc.gov.uk
 options: --query-string prod_id:sub_tech_id

--- a/data/transition-sites/decc_gdcb.yml
+++ b/data/transition-sites/decc_gdcb.yml
@@ -1,7 +1,7 @@
 ---
 site: decc_gdcb
-whitehall_slug: department-of-energy-climate-change
-homepage: https://www.gov.uk/government/organisations/department-of-energy-climate-change
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20130922123008
 host: gdcashback.decc.gov.uk
-homepage_furl: www.gov.uk/decc
+homepage_furl: www.gov.uk/beis

--- a/data/transition-sites/decc_mrws.yml
+++ b/data/transition-sites/decc_mrws.yml
@@ -1,8 +1,8 @@
 ---
 site: decc_mrws
-whitehall_slug: department-of-energy-climate-change
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 host: mrws.decc.gov.uk
 tna_timestamp: 20121217150421
-homepage_furl: www.gov.uk/decc
-homepage: https://www.gov.uk/government/policies/managing-the-use-and-disposal-of-radioactive-and-nuclear-substances-and-waste
+homepage_furl: www.gov.uk/beis
 css: department-of-energy-climate-change

--- a/data/transition-sites/decc_mrws.yml
+++ b/data/transition-sites/decc_mrws.yml
@@ -1,6 +1,6 @@
 ---
 site: decc_mrws
 whitehall_slug: department-for-business-energy-and-industrial-strategy
-homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/policies/radioactive-and-nuclear-substances-and-waste
 host: mrws.decc.gov.uk
 tna_timestamp: 20121217150421

--- a/data/transition-sites/decc_mrws.yml
+++ b/data/transition-sites/decc_mrws.yml
@@ -5,4 +5,3 @@ homepage: https://www.gov.uk/government/organisations/department-for-business-en
 host: mrws.decc.gov.uk
 tna_timestamp: 20121217150421
 homepage_furl: www.gov.uk/beis
-css: department-of-energy-climate-change

--- a/data/transition-sites/decc_mrws.yml
+++ b/data/transition-sites/decc_mrws.yml
@@ -4,4 +4,3 @@ whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 host: mrws.decc.gov.uk
 tna_timestamp: 20121217150421
-homepage_furl: www.gov.uk/beis

--- a/data/transition-sites/decc_offshoresea.yml
+++ b/data/transition-sites/decc_offshoresea.yml
@@ -1,7 +1,7 @@
 ---
 site: decc_offshoresea
 whitehall_slug: department-for-business-energy-and-industrial-strategy
-homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/guidance/offshore-energy-strategic-environmental-assessment-sea-an-overview-of-the-sea-process
 host: www.offshore-sea.org.uk
 aliases:
 - offshore-sea.org.uk

--- a/data/transition-sites/decc_offshoresea.yml
+++ b/data/transition-sites/decc_offshoresea.yml
@@ -6,5 +6,4 @@ host: www.offshore-sea.org.uk
 aliases:
 - offshore-sea.org.uk
 tna_timestamp: 20130103064208
-homepage_furl: www.gov.uk/beis
 options: --query-string faqid:link:categoryid:documentid:pagenumber:fileid:meetingid:bookid:consultationid:productid:downloadid:newsid

--- a/data/transition-sites/decc_offshoresea.yml
+++ b/data/transition-sites/decc_offshoresea.yml
@@ -1,11 +1,11 @@
 ---
 site: decc_offshoresea
-whitehall_slug: department-of-energy-climate-change
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 host: www.offshore-sea.org.uk
 aliases:
 - offshore-sea.org.uk
 tna_timestamp: 20130103064208
-homepage_furl: www.gov.uk/decc
-homepage: https://www.gov.uk/offshore-energy-strategic-environmental-assessment-sea-an-overview-of-the-sea-process
+homepage_furl: www.gov.uk/beis
 options: --query-string faqid:link:categoryid:documentid:pagenumber:fileid:meetingid:bookid:consultationid:productid:downloadid:newsid
 css: department-of-energy-climate-change

--- a/data/transition-sites/decc_offshoresea.yml
+++ b/data/transition-sites/decc_offshoresea.yml
@@ -8,4 +8,3 @@ aliases:
 tna_timestamp: 20130103064208
 homepage_furl: www.gov.uk/beis
 options: --query-string faqid:link:categoryid:documentid:pagenumber:fileid:meetingid:bookid:consultationid:productid:downloadid:newsid
-css: department-of-energy-climate-change

--- a/data/transition-sites/decc_og.yml
+++ b/data/transition-sites/decc_og.yml
@@ -1,10 +1,10 @@
 ---
 site: decc_og
-whitehall_slug: department-of-energy-climate-change
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 host: og.decc.gov.uk
 tna_timestamp: 20121217150421
-homepage_furl: www.gov.uk/decc
-homepage: https://www.gov.uk/government/organisations/department-of-energy-climate-change
+homepage_furl: www.gov.uk/beis
 css: department-of-energy-climate-change
 aliases:
 - www.og.bis.gov.uk

--- a/data/transition-sites/decc_og.yml
+++ b/data/transition-sites/decc_og.yml
@@ -5,7 +5,6 @@ homepage: https://www.gov.uk/government/organisations/department-for-business-en
 host: og.decc.gov.uk
 tna_timestamp: 20121217150421
 homepage_furl: www.gov.uk/beis
-css: department-of-energy-climate-change
 aliases:
 - www.og.bis.gov.uk
 - og.bis.gov.uk

--- a/data/transition-sites/decc_restats.yml
+++ b/data/transition-sites/decc_restats.yml
@@ -1,7 +1,7 @@
 ---
 site: decc_restats
 whitehall_slug: department-for-business-energy-and-industrial-strategy
-homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/collections/renewables-statistics
 tna_timestamp: 20140711173142
 host: restats.decc.gov.uk
 special_redirect_strategy: via_aka

--- a/data/transition-sites/decc_restats.yml
+++ b/data/transition-sites/decc_restats.yml
@@ -1,10 +1,10 @@
 ---
 site: decc_restats
-whitehall_slug: department-of-energy-climate-change
-homepage: https://www.gov.uk/government/collections/renewables-statistics
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20140711173142
 host: restats.decc.gov.uk
-homepage_furl: www.gov.uk/decc
+homepage_furl: www.gov.uk/beis
 special_redirect_strategy: via_aka
 # This special redirect strategy is to exclude an interactive map at
 # http://restats.decc.gov.uk/app/pub/map/map/

--- a/data/transition-sites/decc_restats.yml
+++ b/data/transition-sites/decc_restats.yml
@@ -4,7 +4,6 @@ whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20140711173142
 host: restats.decc.gov.uk
-homepage_furl: www.gov.uk/beis
 special_redirect_strategy: via_aka
 # This special redirect strategy is to exclude an interactive map at
 # http://restats.decc.gov.uk/app/pub/map/map/

--- a/data/transition-sites/ukti_makingitgreat.yml
+++ b/data/transition-sites/ukti_makingitgreat.yml
@@ -1,7 +1,7 @@
 ---
 site: ukti_makingitgreat
-whitehall_slug: department-for-business-innovation-skills
-homepage: https://www.gov.uk/government/organisations/department-for-business-innovation-skills
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20140108125810
 host: makeitingreatbritain.bis.gov.uk
 homepage_furl: www.gov.uk/ukti


### PR DESCRIPTION
BIS has changed their name to BEIS. This commit changes all the Whitehall slugs
and homepages and homepage furls as required.
We also added some extra organisation slugs for some orgs that required it.

https://trello.com/c/KKaIos2q/520-update-org-slugs-in-transition-after-mog-changes-1