### PR TITLE
Rename Wales Office

### DIFF
--- a/data/transition-sites/walesoffice.yml
+++ b/data/transition-sites/walesoffice.yml
@@ -1,8 +1,8 @@
 ---
 site: walesoffice
-whitehall_slug: wales-office
+whitehall_slug: office-of-the-secretary-of-state-for-wales
 host: www.walesoffice.gov.uk
 tna_timestamp: 20130129084240
-homepage_furl: www.gov.uk/wales-office
-homepage: https://www.gov.uk/government/organisations/wales-office
+homepage_furl: www.gov.uk/wales
+homepage: https://www.gov.uk/government/organisations/office-of-the-secretary-of-state-for-wales
 css: wales-office

--- a/data/transition-sites/walesoffice_cymru.yml
+++ b/data/transition-sites/walesoffice_cymru.yml
@@ -1,9 +1,9 @@
 ---
 site: walesoffice_cymru
-whitehall_slug: wales-office
+whitehall_slug: office-of-the-secretary-of-state-for-wales
 host: www.swyddfa.cymru.gov.uk
 tna_timestamp: 20130129084344
 homepage_title: Swyddfa Cymru
-homepage_furl: www.gov.uk/wales-office
-homepage: https://www.gov.uk/government/organisations/wales-office.cy
+homepage_furl: www.gov.uk/cymru
+homepage: https://www.gov.uk/government/organisations/office-of-the-secretary-of-state-for-wales.cy
 css: wales-office


### PR DESCRIPTION
Trello: https://trello.com/c/B764dizv/528-complete-wales-office-rename

`/organisations/wales-office` was recently renamed to
`/organisations/office-of-the-secretary-of-state-for-wales`.

Performing updates as outlined here: 
https://github.gds/pages/gds/opsmanual/2nd-line/changing-organisation-slug.html