### PR TITLE
Add tan.gov.uk global redirect

### DIFF
--- a/data/transition-sites/tan.yml
+++ b/data/transition-sites/tan.yml
@@ -1,0 +1,9 @@
+---
+site: tan
+whitehall_slug: driver-and-vehicle-standards-agency
+homepage: https://www.gov.uk/government/organisations/traffic-commissioners
+tna_timestamp: 20040120115311
+host: www.tan.gov.uk
+aliases:
+- tan.gov.uk
+global: =301 https://www.gov.uk/government/organisations/traffic-commissioners


### PR DESCRIPTION
- Trello card: https://trello.com/c/uDZ37oSB/573-global-redirect-for-www-tan-gov-uk-1
- This adds a global redirect for www.tan.gov.uk to https://www.gov.uk/government/organisations/traffic-commissioners