### PR TITLE
scotland-office organisation slug has changed to uk-government-scotland

### DIFF
--- a/data/transition-sites/scotlandoffice.yml
+++ b/data/transition-sites/scotlandoffice.yml
@@ -1,9 +1,9 @@
 ---
 site: scotlandoffice
-whitehall_slug: scotland-office
+whitehall_slug: uk-government-scotland
 host: www.scotlandoffice.gov.uk
 tna_timestamp: 20130130150421
-homepage_furl: www.gov.uk/scotland-office
-homepage: https://www.gov.uk/government/organisations/scotland-office
+homepage_furl: www.gov.uk/uk-government-scotland
+homepage: https://www.gov.uk/government/organisations/uk-government-scotland
 options: --query-string title:attachment
 css: scotland-office


### PR DESCRIPTION
Part of https://trello.com/c/1NZCWSNV/566-name-changes-to-scotland-office

cc @gpeng 