### PR TITLE
Configure phe_chimat for mappings

### DIFF
--- a/data/transition-sites/phe_chimat.yml
+++ b/data/transition-sites/phe_chimat.yml
@@ -7,4 +7,4 @@ tna_timestamp: 20161101134131
 host: www.chimat.org.uk
 aliases:
 - chimat.org.uk
-global: =301 https://www.gov.uk/government/organisations/public-health-england
+options: --query-string rid


### PR DESCRIPTION
PHE have requested that chimat.org.uk is changed from a global redirect to mappings.
https://trello.com/c/A2Pvv5w1/704-phe-change-configuration-for-chimat-in-the-transition-tool