### PR TITLE
Remove business-support-api redirects

### DIFF
--- a/data/transition-sites/gds_alphagov_business-support-api-preview.yml
+++ b/data/transition-sites/gds_alphagov_business-support-api-preview.yml
@@ -1,8 +1,0 @@
----
-site: gds_alphagov_business-support-api-preview
-whitehall_slug: government-digital-service
-homepage: https://business-support-api.integration.publishing.service.gov.uk
-tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
-host: business-support-api.preview.alphagov.co.uk
-global: =301 https://business-support-api.integration.publishing.service.gov.uk
-global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_business-support-api.yml
+++ b/data/transition-sites/gds_alphagov_business-support-api.yml
@@ -1,8 +1,0 @@
----
-site: gds_alphagov_business-support-api
-whitehall_slug: government-digital-service
-homepage: https://business-support-api.publishing.service.gov.uk
-tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
-host: business-support-api.production.alphagov.co.uk
-global: =301 https://business-support-api.publishing.service.gov.uk
-global_redirect_append_path: true


### PR DESCRIPTION
This commit removes the alphagov redirects for `business-support-api` since the app has been retired.