### PR TITLE
Add Standards Hub site

### DIFF
--- a/data/transition-sites/gds_standards.yml
+++ b/data/transition-sites/gds_standards.yml
@@ -1,0 +1,8 @@
+---
+site: gds_standards
+whitehall_slug: government-digital-service
+homepage: https://www.gov.uk/government/organisations/government-digital-service
+homepage_furl: www.gov.uk/gds
+tna_timestamp: 20161108155955
+host: standards.data.gov.uk
+global: =301 https://www.gov.uk/government/collections/open-standards-for-government-data-and-technology


### PR DESCRIPTION
More details in this Trello card:
https://trello.com/c/EPen5xTi/158-transition-tool-standards-hub

Note that https://www.gov.uk/government/collections/open-standards-for-government-data-and-technology hasn't yet been published.