### PR TITLE
Update chimat.org.uk homepage

### DIFF
--- a/data/transition-sites/phe_chimat.yml
+++ b/data/transition-sites/phe_chimat.yml
@@ -1,10 +1,10 @@
 ---
 site: phe_chimat
 whitehall_slug: public-health-england
-homepage: https://www.gov.uk/government/organisations/public-health-england
+homepage: https://www.gov.uk/guidance/phe-data-and-analysis-tools#child-and-maternal-health
 homepage_furl: www.gov.uk/phe
-tna_timestamp: 20170302100842
+tna_timestamp: 20170302101115
 host: www.chimat.org.uk
 aliases:
 - chimat.org.uk
-options: --query-string rid
+options: --query-string rid:qn


### PR DESCRIPTION
Chimat.org has already been set up in the Transition tool as 'Mappings',
two updates to the configuration are needed.

1. In the transition tool the homepage for chimat.org.uk needs to be
changed to
https://www.gov.uk/guidance/phe-data-and-analysis-tools#child-and-maternal-health

2. Please add "QN" as a significant query parameters to chimat.org.uk in
the transition tool.

Trello: https://trello.com/c/ufSRJS9N/175-transition%3A-update-configuration-of-chimat.org