### PR TITLE
Remove homepage furl for chimat

### DIFF
--- a/data/transition-sites/phe_chimat.yml
+++ b/data/transition-sites/phe_chimat.yml
@@ -2,7 +2,6 @@
 site: phe_chimat
 whitehall_slug: public-health-england
 homepage: https://www.gov.uk/guidance/phe-data-and-analysis-tools#child-and-maternal-health
-homepage_furl: www.gov.uk/phe
 tna_timestamp: 20170302101115
 host: www.chimat.org.uk
 aliases:


### PR DESCRIPTION
The homepage is no longer the organisation page, so we should remove this `homepage_furl`.

This was mentioned by @jennyd on https://github.com/alphagov/transition-config/pull/1229

Trello: https://trello.com/c/ufSRJS9N/175-transition%3A-update-configuration-of-chimat.org