### PR TITLE
Setup voa domains

### DIFF
--- a/data/transition-sites/voa.yml
+++ b/data/transition-sites/voa.yml
@@ -7,8 +7,6 @@ host: www.voa.gov.uk
 homepage_furl: www.gov.uk/voa
 aliases:
 - voa.gov.uk
-- app.voa.gov.uk
 - cti.voa.gov.uk
-- manuals.voa.gov.uk
 - www.manuals.voa.gov.uk
 options: --query-string lcn:ebar

--- a/data/transition-sites/voa_app.yml
+++ b/data/transition-sites/voa_app.yml
@@ -1,0 +1,7 @@
+---
+site: voa_app
+whitehall_slug: valuation-office-agency
+homepage: https://www.gov.uk/government/organisations/valuation-office-agency
+homepage_furl: www.gov.uk/voa
+tna_timestamp: 20170531000000
+host: app.voa.gov.uk

--- a/data/transition-sites/voa_manuals.yml
+++ b/data/transition-sites/voa_manuals.yml
@@ -1,0 +1,7 @@
+---
+site: voa_manuals
+whitehall_slug: valuation-office-agency
+homepage: https://www.gov.uk/government/organisations/valuation-office-agency
+homepage_furl: www.gov.uk/voa
+tna_timestamp: 20170531000000
+host: manuals.voa.gov.uk


### PR DESCRIPTION
VOA asked for both `app.voa.gov.uk` and `manuals.voa.gov.uk` to be configured for mappings. These commits make sure we setup both as separate sites and also remove them from the list ot aliases.

Trello: https://trello.com/c/JYhmGEZw/52-configure-transition-tool-for-voa-subdomains