### PR TITLE
Configure global redirect for www.beis.gov.uk

### DIFF
--- a/data/transition-sites/beis.yml
+++ b/data/transition-sites/beis.yml
@@ -1,0 +1,9 @@
+---
+site: beis
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+tna_timestamp: 20170612110308
+host: www.beis.gov.uk
+global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+aliases:
+- beis.gov.uk


### PR DESCRIPTION
We need to setup:
www.beis.gov.uk
http://beis.gov.uk

It should be configured as a global redirect to:
https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy

There is no TNA timestamp as the site does not exist.

For the purposes of the 410 page, the home page should be:
https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy