### PR TITLE
Update TNA timestamps for Sellafield sites

### DIFF
--- a/data/transition-sites/sellafield_sellafieldsites.yml
+++ b/data/transition-sites/sellafield_sellafieldsites.yml
@@ -2,7 +2,7 @@
 site: sellafield_sellafieldsites
 whitehall_slug: sellafield-ltd
 homepage: https://www.gov.uk/government/organisations/sellafield-ltd
-tna_timestamp: 20150203000102 # http://webarchive.nationalarchives.gov.uk/20150203000102/http://www.sellafieldsites.com/
+tna_timestamp: 20170712122213
 host: www.sellafieldsites.com
 options: --query-string post_id
 aliases:

--- a/data/transition-sites/sellafield_supliers.yml
+++ b/data/transition-sites/sellafield_supliers.yml
@@ -2,5 +2,5 @@
 site: sellafield_supliers
 whitehall_slug: sellafield-ltd
 homepage: https://www.gov.uk/government/organisations/sellafield-ltd
-tna_timestamp: 20150203000102 # TEMPORARY
+tna_timestamp: 20170712122213
 host: suppliers.sellafieldsites.com

--- a/data/transition-sites/sellafield_sustainability.yml
+++ b/data/transition-sites/sellafield_sustainability.yml
@@ -2,5 +2,5 @@
 site: sellafield_sustainability
 whitehall_slug: sellafield-ltd
 homepage: https://www.gov.uk/government/organisations/sellafield-ltd
-tna_timestamp: 20150203000102 # TEMPORARY
+tna_timestamp: 20170712122213
 host: sustainability.sellafieldsites.com


### PR DESCRIPTION
The www.sellafieldsites.com timestamp came from Sellafield, the others were the
latest snapshots available on the national archives website.

https://trello.com/c/hyufd3IP/97-set-up-more-sellafield-domains-in-transition-tool