### PR TITLE
Remove the sellafield careers site

### DIFF
--- a/data/transition-sites/sellafield_sellafieldcareers.yml
+++ b/data/transition-sites/sellafield_sellafieldcareers.yml
@@ -1,6 +1,0 @@
----
-site: sellafield_sellafieldcareers
-whitehall_slug: sellafield-ltd
-homepage: https://www.gov.uk/government/organisations/sellafield-ltd
-tna_timestamp: 20150203000102 # TEMPORARY
-host: careers.sellafieldsite.co.uk


### PR DESCRIPTION
This isn't being transitioned.

Paired with @koetsier, @cbaines.

https://trello.com/c/hyufd3IP/97-set-up-more-sellafield-domains-in-transition-tool