### PR TITLE
Alter the handling of two UKVI related domains

### DIFF
--- a/data/transition-sites/ukvi.yml
+++ b/data/transition-sites/ukvi.yml
@@ -7,10 +7,8 @@ homepage: https://www.gov.uk/government/organisations/uk-visas-and-immigration
 aliases:
 - bia.homeoffice.gov.uk
 - biapreview.homeoffice.gov.uk
-- contact-ukba.homeoffice.gov.uk
 - ind.homeoffice.gov.uk
 - origin.ukba.homeoffice.gov.uk # Currently used for us to serve proxied content. Will move eventually.
-- report-ukba.homeoffice.gov.uk
 - ukba.homeoffice.gov.uk
 - www.bia.homeoffice.gov.uk
 - www.biapreview.homeoffice.gov.uk

--- a/data/transition-sites/ukvi_contact.yml
+++ b/data/transition-sites/ukvi_contact.yml
@@ -1,0 +1,7 @@
+---
+site: ukvi_contact
+whitehall_slug: uk-visas-and-immigration
+homepage: https://www.gov.uk/government/organisations/uk-visas-and-immigration
+tna_timestamp: 20140110181512
+host: contact-ukba.homeoffice.gov.uk
+global: =301 https://eforms.homeoffice.gov.uk/outreach/AddressUpdate.ofml

--- a/data/transition-sites/ukvi_report.yml
+++ b/data/transition-sites/ukvi_report.yml
@@ -1,0 +1,7 @@
+---
+site: ukvi_report
+whitehall_slug: uk-visas-and-immigration
+homepage: https://www.gov.uk/government/organisations/uk-visas-and-immigration
+tna_timestamp: 20140110181512
+host: report-ukba.homeoffice.gov.uk
+global: =301 https://eforms.homeoffice.gov.uk/outreach/righttowork.ofml


### PR DESCRIPTION
These domains are currently handled through Dyn (dyn.com), and the
configuration for each domain is to redirect all requests to a single
page (different page for each domain).

The configuration here for these domains is to handle them as aliases
for www.ukba.homeoffice.gov.uk, which has a set of mappings in the
transition app to give different redirects based on the request path.

To make the behaviour of transition/bouncer match that currently setup
through Dyn, split the handling of these two domains out, and
configure the respective global redirects.

This will mean that should the traffic be sent to bouncer, the
behaviour stay the same. This will enable removing the configuration
from Dyn.

https://trello.com/c/Ci4cB9R0