### PR TITLE
Remove two redundant aliases for UKVI

### DIFF
--- a/data/transition-sites/ukvi.yml
+++ b/data/transition-sites/ukvi.yml
@@ -7,10 +7,8 @@ homepage: https://www.gov.uk/government/organisations/uk-visas-and-immigration
 aliases:
 - bia.homeoffice.gov.uk
 - biapreview.homeoffice.gov.uk
-- contact-ukba.homeoffice.gov.uk
 - ind.homeoffice.gov.uk
 - origin.ukba.homeoffice.gov.uk # Currently used for us to serve proxied content. Will move eventually.
-- report-ukba.homeoffice.gov.uk
 - ukba.homeoffice.gov.uk
 - www.bia.homeoffice.gov.uk
 - www.biapreview.homeoffice.gov.uk


### PR DESCRIPTION
These domains are currently handled through Dyn (dyn.com), therefore
remove them from the transition configuration, as neither Transition
or Bouncer need to know about them.

Replacement for: https://github.com/alphagov/transition-config/pull/1248

Trello: https://trello.com/c/Ci4cB9R0