### PR TITLE
Revert "Remove two redundant aliases for UKVI"

### DIFF
--- a/data/transition-sites/ukvi.yml
+++ b/data/transition-sites/ukvi.yml
@@ -7,8 +7,10 @@ homepage: https://www.gov.uk/government/organisations/uk-visas-and-immigration
 aliases:
 - bia.homeoffice.gov.uk
 - biapreview.homeoffice.gov.uk
+- contact-ukba.homeoffice.gov.uk
 - ind.homeoffice.gov.uk
 - origin.ukba.homeoffice.gov.uk # Currently used for us to serve proxied content. Will move eventually.
+- report-ukba.homeoffice.gov.uk
 - ukba.homeoffice.gov.uk
 - www.bia.homeoffice.gov.uk
 - www.biapreview.homeoffice.gov.uk


### PR DESCRIPTION
After this configuration change was merged and deployed, the Host
entries coresponding to the  contact-ukba.homeoffice.gov.uk were
deleted.

This broke the Transition_load_all_data job, as there were host_paths
that referenced the deleted host.

This database change has now been reversed, and the deleted records
restored (details here [1]).

It seems sensible to make the coresponding change in the
configuration, with the expectation that this won't change the
database, as coresponding host entries already exist for these
aliases.

1: https://github.com/alphagov/govuk-org-notes/blob/master/Debugging%20the%20Transition_load_all_data%20Jenkins%20job%20failures.org

This reverts commit 9ce925400e42c6003bad2140847184c83764826f.