### PR TITLE
Add global archive for www.lape.org.uk

### DIFF
--- a/data/transition-sites/phe_lape.yml
+++ b/data/transition-sites/phe_lape.yml
@@ -1,0 +1,8 @@
+---
+site: phe_lape
+whitehall_slug: public-health-england
+homepage: https://fingertips.phe.org.uk/profile/local-alcohol-profiles
+tna_timestamp: 20170808112813
+host: www.lape.org.uk
+global: =410
+homepage_title: 'Local Alcohol Profiles'


### PR DESCRIPTION
For https://trello.com/c/I2LxlURw/55-phe-transition-request

This one seems a bit non-standard in that we set the homepage to be
a non-GOV.UK website, but the fingertips.phe.org.uk domain is in the
transition whitelist so this should be fine...

There's prior art for this sort of archiving request, check out 'dclg_localdirect.yml'