### PR TITLE
Add global redirect for cabinet-office.gov.uk

### DIFF
--- a/data/transition-sites/cabinet-office.yml
+++ b/data/transition-sites/cabinet-office.yml
@@ -1,0 +1,9 @@
+---
+site: cabinet-office
+whitehall_slug: cabinet-office
+homepage: https://www.gov.uk/government/organisations/cabinet-office
+tna_timestamp: 20130128190123
+host: www.cabinet-office.gov.uk
+aliases:
+- cabinet-office.gov.uk
+global: =301 https://www.gov.uk/government/organisations/cabinet-office


### PR DESCRIPTION
For https://trello.com/c/K3lE5079/89-transition-request-set-up-cabinet-officegovuk-global-redirect-to-govuk

This is a bit of a weird one as visiting the site 'cabinet-office.gov.uk' already redirects to its relevant GOV.UK organisation page. Looking at the chain of redirects, it looks like 'cabinet-office.gov.uk' redirects to 'cabinetoffice.gov.uk' which is already set up in the Transition tool, so it seems appropriate to make an entry for 'cabinet-office.gov.uk'.