### PR TITLE
Add alias for non-www DECC site

### DIFF
--- a/data/transition-sites/decc.yml
+++ b/data/transition-sites/decc.yml
@@ -6,3 +6,5 @@ host: www.decc.gov.uk
 tna_timestamp: 20121217150421
 homepage_furl: www.gov.uk/beis
 options: --query-string filepath
+aliases:
+- decc.gov.uk


### PR DESCRIPTION
We have had a support request raising the issue that the DECC site is
not redirecting. The Zendesk ticket [1] covers both the www.decc.gov.uk
and decc.gov.uk domains, which I believe are seperate issues.

The naked domain site has the correct A records set:

$ host decc.gov.uk
decc.gov.uk has address 151.101.194.30
decc.gov.uk has address 151.101.66.30
decc.gov.uk has address 151.101.130.30
decc.gov.uk has address 151.101.2.30

However, for host www.decc.gov.uk, there seems to be some DNS records
missing:

$ host www.decc.gov.uk
Host www.decc.gov.uk not found: 3(NXDOMAIN)

Our configuration for the DECC site only covers the www domain, but as
their non-www domain is the only site with correct DNS we receive the
following error when viewing the non-www site:

$ curl decc.gov.uk
This host is not configured in Transition

This is because we do not have the decc.gov.uk domain as an alias value

[1] https://govuk.zendesk.com/agent/tickets/2515421

---

[Trello: Investigate BEIS / DECC  redirect issue](https://trello.com/c/cbgqXoxm/163-investigate-beis-decc-redirect-issue)