### PR TITLE
Add non-www entry to www.lowpay.gov.uk site

### DIFF
--- a/data/transition-sites/bis_lowpay.yml
+++ b/data/transition-sites/bis_lowpay.yml
@@ -8,3 +8,4 @@ homepage: https://www.gov.uk/government/organisations/low-pay-commission
 aliases:
 - www2.lowpay.gov.uk
 - search.lowpay.gov.uk
+- lowpay.gov.uk


### PR DESCRIPTION
Zendesk ticket: https://govuk.zendesk.com/agent/tickets/2515315

---

[Trello: Non www redirect for www.lowpay.gov.uk](https://trello.com/c/7T0Msyxa/165-non-www-redirect-for-wwwlowpaygovuk)