### PR TITLE
Add transition for blog.landregistry.gov.uk

### DIFF
--- a/data/transition-sites/landregistry_blog.yml
+++ b/data/transition-sites/landregistry_blog.yml
@@ -1,0 +1,6 @@
+---
+site: landregistry_blog
+whitehall_slug: land-registry
+homepage: https://hmlandregistry.blog.gov.uk
+tna_timestamp: 20170712122232
+host: blog.landregistry.gov.uk


### PR DESCRIPTION
Transition from old blog (http://blog.landregistry.gov.uk/) to new blog (https://landregistry.blog.gov.uk/)

- tna_timestamp has not been confirmed; it was obtained from the tna website.

Trello: https://trello.com/c/zFNVPYzp/181-land-registry-blog-transition-request