### PR TITLE
Rename DH and DCLG

### DIFF
--- a/data/transition-sites/dclg.yml
+++ b/data/transition-sites/dclg.yml
@@ -1,12 +1,12 @@
 ---
 site: dclg
-whitehall_slug: department-for-communities-and-local-government
+whitehall_slug: ministry-of-housing-communities-and-local-government
 host: www.communities.gov.uk
 tna_timestamp: 20120919132719
 homepage_furl: www.gov.uk/dclg
-homepage: https://www.gov.uk/government/organisations/department-for-communities-and-local-government
+homepage: https://www.gov.uk/government/organisations/ministry-of-housing-communities-and-local-government
 aliases:
 - communities.gov.uk
 - dclg.gov.uk
 - www.dclg.gov.uk
-css: department-for-communities-and-local-government
+css: ministry-of-housing-communities-and-local-government

--- a/data/transition-sites/dclg_bb.yml
+++ b/data/transition-sites/dclg_bb.yml
@@ -1,6 +1,6 @@
 ---
 site: dclg_bb
-whitehall_slug: department-for-communities-and-local-government
+whitehall_slug: ministry-of-housing-communities-and-local-government
 homepage: https://www.gov.uk/government/publications/sustainable-communities-act-and-barrier-busting
 tna_timestamp: 20150310032258
 host: barrierbusting.communities.gov.uk

--- a/data/transition-sites/dclg_fire.yml
+++ b/data/transition-sites/dclg_fire.yml
@@ -1,6 +1,6 @@
 ---
 site: dclg_fire
-whitehall_slug: department-for-communities-and-local-government
+whitehall_slug: ministry-of-housing-communities-and-local-government
 homepage: https://www.gov.uk/government/policies/fire-prevention-and-rescue
 tna_timestamp: 20100105005659
 host: fire.gov.uk

--- a/data/transition-sites/dclg_lf.yml
+++ b/data/transition-sites/dclg_lf.yml
@@ -1,6 +1,6 @@
 ---
 site: dclg_lf
-whitehall_slug: department-for-communities-and-local-government
+whitehall_slug: ministry-of-housing-communities-and-local-government
 homepage: https://www.gov.uk/government/collections/final-local-government-finance-settlement-england-2014-to-2015
 tna_timestamp: 20140505104649
 host: www.local.communities.gov.uk

--- a/data/transition-sites/dclg_localdirect.yml
+++ b/data/transition-sites/dclg_localdirect.yml
@@ -1,6 +1,6 @@
 ---
 site: dclg_localdirect
-whitehall_slug: department-for-communities-and-local-government
+whitehall_slug: ministry-of-housing-communities-and-local-government
 homepage: http://www.localdigitalcoalition.uk
 tna_timestamp: 20160330154530
 host: www.localdirect.gov.uk

--- a/data/transition-sites/dclg_mp.yml
+++ b/data/transition-sites/dclg_mp.yml
@@ -1,7 +1,7 @@
 ---
 site: dclg_mp
-whitehall_slug: department-for-communities-and-local-government
-homepage: https://www.gov.uk/government/organisations/department-for-communities-and-local-government
+whitehall_slug: ministry-of-housing-communities-and-local-government
+homepage: https://www.gov.uk/government/organisations/ministry-of-housing-communities-and-local-government
 tna_timestamp: 20131010112452
 host: markprisk.communities.gov.uk
 global: =410

--- a/data/transition-sites/dclg_newlove.yml
+++ b/data/transition-sites/dclg_newlove.yml
@@ -1,7 +1,7 @@
 ---
 site: dclg_newlove
-whitehall_slug: department-for-communities-and-local-government
-homepage: https://www.gov.uk/government/organisations/department-for-communities-and-local-government
+whitehall_slug: ministry-of-housing-communities-and-local-government
+homepage: https://www.gov.uk/government/organisations/ministry-of-housing-communities-and-local-government
 tna_timestamp: 20140701125431
 host: www.helennewlove.co.uk
 global: =410

--- a/data/transition-sites/dclg_nip.yml
+++ b/data/transition-sites/dclg_nip.yml
@@ -1,8 +1,8 @@
 ---
 site: dclg_nip
-whitehall_slug: department-for-communities-and-local-government
+whitehall_slug: ministry-of-housing-communities-and-local-government
 homepage_title: 'National Infrastructure Planning'
-homepage: https://www.gov.uk/government/organisations/department-for-communities-and-local-government
+homepage: https://www.gov.uk/government/organisations/ministry-of-housing-communities-and-local-government
 tna_timestamp: 20140713173346
 host: infrastructure.planningportal.gov.uk
 homepage_furl: www.gov.uk/dclg

--- a/data/transition-sites/dclg_pg.yml
+++ b/data/transition-sites/dclg_pg.yml
@@ -1,6 +1,6 @@
 ---
 site: dclg_pg
-whitehall_slug: department-for-communities-and-local-government
+whitehall_slug: ministry-of-housing-communities-and-local-government
 homepage: https://www.gov.uk/government/consultations/review-of-planning-practice-guidance
 tna_timestamp: 20140701125403
 host: planningguidance.readandcomment.com

--- a/data/transition-sites/dclg_planning.yml
+++ b/data/transition-sites/dclg_planning.yml
@@ -1,6 +1,6 @@
 ---
 site: dclg_planning
-whitehall_slug: department-for-communities-and-local-government
+whitehall_slug: ministry-of-housing-communities-and-local-government
 homepage: https://www.gov.uk/government/collections/planning-practice-guidance 
 homepage_title: Planning guidance
 tna_timestamp: 20140724121321

--- a/data/transition-sites/dh.yml
+++ b/data/transition-sites/dh.yml
@@ -1,10 +1,10 @@
 ---
 site: dh
-whitehall_slug: department-of-health
+whitehall_slug: department-of-health-and-social-care
 host: www.dh.gov.uk
 tna_timestamp: 20130107105354
 homepage_furl: www.gov.uk/dh
-homepage: https://www.gov.uk/government/organisations/department-of-health
+homepage: https://www.gov.uk/government/organisations/department-of-health-and-social-care
 aliases:
 - dh.gov.uk
-css: department-of-health
+css: department-of-health-and-social-care

--- a/data/transition-sites/dh_blog.yml
+++ b/data/transition-sites/dh_blog.yml
@@ -1,6 +1,6 @@
 ---
 site: dh_blog
-whitehall_slug: department-of-health
+whitehall_slug: department-of-health-and-social-care
 homepage_title: 'Department of Health Digital Health'
 homepage: https://digitalhealth.blog.gov.uk
 tna_timestamp: 20140522191340

--- a/data/transition-sites/dh_cmu.yml
+++ b/data/transition-sites/dh_cmu.yml
@@ -1,6 +1,6 @@
 ---
 site: dh_cmu
-whitehall_slug: department-of-health
+whitehall_slug: department-of-health-and-social-care
 homepage_title: 'Commercial Medicines Unit'
 homepage: https://www.gov.uk/government/collections/commercial-medicines-unit-cmu
 tna_timestamp: 20140908135505

--- a/data/transition-sites/dh_hale.yml
+++ b/data/transition-sites/dh_hale.yml
@@ -1,6 +1,6 @@
 ---
 site: dh_hale
-whitehall_slug: department-of-health
+whitehall_slug: department-of-health-and-social-care
 homepage: http://digitalhealth.blog.gov.uk/author/stephenhale
 tna_timestamp: 20140402154639
 host: hale.dh.gov.uk

--- a/data/transition-sites/dh_immunisation.yml
+++ b/data/transition-sites/dh_immunisation.yml
@@ -1,10 +1,10 @@
 ---
 site: dh_immunisation
-whitehall_slug: department-of-health
+whitehall_slug: department-of-health-and-social-care
 host: immunisation.dh.gov.uk
 tna_timestamp: 20130107105354
 homepage_furl: www.gov.uk/dh
 homepage: https://www.gov.uk/government/organisations/public-health-england/series/immunisation
-css: department-of-health
+css: department-of-health-and-social-care
 aliases:
 - www.immunisation.dh.gov.uk

--- a/data/transition-sites/dh_mediacentre.yml
+++ b/data/transition-sites/dh_mediacentre.yml
@@ -1,8 +1,8 @@
 ---
 site: dh_mediacentre
-whitehall_slug: department-of-health
+whitehall_slug: department-of-health-and-social-care
 host: mediacentre.dh.gov.uk
 tna_timestamp: 20130107105354
 homepage_furl: www.gov.uk/dh
-homepage: https://www.gov.uk/government/organisations/department-of-health
-css: department-of-health
+homepage: https://www.gov.uk/government/organisations/department-of-health-and-social-care
+css: department-of-health-and-social-care

--- a/data/transition-sites/dh_publications.yml
+++ b/data/transition-sites/dh_publications.yml
@@ -1,8 +1,8 @@
 ---
 site: dh_publications
-whitehall_slug: department-of-health
+whitehall_slug: department-of-health-and-social-care
 host: publications.dh.gov.uk
 tna_timestamp: 20130107105354
 homepage_furl: www.gov.uk/dh
-homepage: https://www.gov.uk/government/organisations/department-of-health
-css: department-of-health
+homepage: https://www.gov.uk/government/organisations/department-of-health-and-social-care
+css: department-of-health-and-social-care

--- a/data/transition-sites/dh_vivblog.yml
+++ b/data/transition-sites/dh_vivblog.yml
@@ -1,6 +1,6 @@
 ---
 site: dh_vivblog
-whitehall_slug: department-of-health
+whitehall_slug: department-of-health-and-social-care
 homepage: https://vivbennett.blog.gov.uk
 tna_timestamp: 20150101010101
 host: vivbennett.dh.gov.uk

--- a/data/transition-sites/directgov_firekills.yml
+++ b/data/transition-sites/directgov_firekills.yml
@@ -3,7 +3,7 @@ site: directgov_firekills
 whitehall_slug: government-digital-service
 homepage: https://www.gov.uk/firekills
 extra_organisation_slugs:
-- department-for-communities-and-local-government
+- ministry-of-housing-communities-and-local-government
 tna_timestamp: 20121106112314
 host: firekills.direct.gov.uk
 global: =301 https://www.gov.uk/firekills


### PR DESCRIPTION
Following on from https://github.com/alphagov/whitehall/pull/3669, this PR renames DH and DCLG to DHSC and MHCLG for transitioned sites.