### PR TITLE
Update Jenkinsfile to use the external govuk library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,9 @@
 
 REPOSITORY = 'transition-config'
 
-node {
-  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+library("govuk")
 
+node {
   try {
     stage('Checkout') {
       checkout scm


### PR DESCRIPTION
- This was extracted into https://github.com/alphagov/govuk-jenkinslib and the
  docs updated to specify this as the new way of loading the library.