### PR TITLE
Add NDA as an extra organisation to various NDA sites

### DIFF
--- a/data/transition-sites/nda_dounreay.yml
+++ b/data/transition-sites/nda_dounreay.yml
@@ -6,3 +6,5 @@ tna_timestamp: 20180117143853
 host: dounreay.com
 aliases:
   - www.dounreay.com
+extra_organisation_slugs:
+  - nuclear-decommissioning-authority

--- a/data/transition-sites/nda_llwr.yml
+++ b/data/transition-sites/nda_llwr.yml
@@ -6,3 +6,5 @@ tna_timestamp: 20180313170246
 host: llwrsite.com
 aliases:
   - www.llwrsite.com
+extra_organisation_slugs:
+  - nuclear-decommissioning-authority

--- a/data/transition-sites/nda_magnox.yml
+++ b/data/transition-sites/nda_magnox.yml
@@ -6,3 +6,5 @@ tna_timestamp: 20171011143403
 host: magnoxsites.com
 aliases:
   - www.magnoxsites.com
+extra_organisation_slugs:
+  - nuclear-decommissioning-authority


### PR DESCRIPTION
These sites are each part of an organisation which works with the NDA. By including this configuration we allow members of the NDA organisation to also edit these sites which has been requested.\

[Trello Card](https://trello.com/c/rFRhyK9V/53-transition-these-3-sites-to-govuk-3)