### PR TITLE
Add GDS Legislation global redirect

### DIFF
--- a/data/transition-sites/gds_legislation.yml
+++ b/data/transition-sites/gds_legislation.yml
@@ -1,0 +1,9 @@
+---
+site: gds_legislation
+whitehall_slug: government-digital-service
+homepage: https://www.gov.uk/government/organisations/government-digital-service
+homepage_furl: www.gov.uk/gds
+tna_timestamp: 20170714000000
+host: legislation.data.gov.uk
+global: =301 http://www.legislation.gov.uk
+global_redirect_append_path: true


### PR DESCRIPTION
https://trello.com/c/QAkRwBJm/426-cleanup-dgu-dns-entries

The domain legislation.data.gov.uk is currently redirected using a
legacy Akamai service, which we would like to discontinue. A possible
consequence of this existing redirect is that this site is not present
in the National Archive, except for a couple of specific pages upon
which the tna_timestamp value is based.