### PR TITLE
Add redirects for think.direct.gov.uk

### DIFF
--- a/data/transition-sites/directgov_talesoftheroad.yml
+++ b/data/transition-sites/directgov_talesoftheroad.yml
@@ -1,0 +1,8 @@
+---
+site: directgov_talesoftheroad
+whitehall_slug: government-digital-service
+homepage: https://www.gov.uk/government/organisations/government-digital-service
+tna_timestamp: 20181018133000
+host: talesoftheroad.direct.gov.uk
+global: =301 http://think.gov.uk
+css: directgov

--- a/data/transition-sites/directgov_think.yml
+++ b/data/transition-sites/directgov_think.yml
@@ -1,0 +1,8 @@
+---
+site: directgov_think
+whitehall_slug: government-digital-service
+homepage: https://www.gov.uk/government/organisations/government-digital-service
+tna_timestamp: 20181018134000
+host: think.direct.gov.uk
+global: =301 http://think.gov.uk
+css: directgov


### PR DESCRIPTION
- Redirection was requested by DfT via https://govuk.zendesk.com/agent/tickets/3406682

- The DNS redirect got active before this change, unfortunately

solo: @schmie