### PR TITLE
Add stub timestamp instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,13 @@ Aside: extra hostnames can be added later.
 
 The generated file only contains fields which are absolutely required.
 
-Check that the `tna_timestamp` field is set. The rake task will try to find the latest archive by scraping the National Archives site, but this doesn't always work. You can find a list of the timestamps the National Archives have by going to their site, for example: [here are the timestamps for this Cabinet Office site](http://webarchive.nationalarchives.gov.uk/*/http://download.cabinetoffice.gov.uk>)
+Check that the `tna_timestamp` field is set. The rake task will try to find the latest archive by scraping the National Archives site, but this doesn't always work. You can find a list of the timestamps the National Archives have by going to their site, for example: [here are the timestamps for this Cabinet Office site](http://webarchive.nationalarchives.gov.uk/*/http://download.cabinetoffice.gov.uk>).
+
+If the site has not been crawled by the National Archives, you can [follow prior art](https://github.com/alphagov/transition-config/search?q=tna_timestamp%3A+20201010101010+%23+Stub+timestamp+-+site+not+in+TNA&unscoped_q=tna_timestamp%3A+20201010101010+%23+Stub+timestamp+-+site+not+in+TNA) and set a stub timestamp:
+
+```
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+```
 
 Some of the optional fields are frequently used:
 

--- a/README.md
+++ b/README.md
@@ -19,23 +19,23 @@ Before you start, you need to know:
 
 Substitute each argument and then run the following rake task (you may need to run `bundle install` first):
 ```
-  rake new_site[abbr,whitehall_slug,host]
+rake new_site[abbr,whitehall_slug,host]
 ```
 
 for example:
 
 ```
-  rake new_site["phe_chimat, public-health-england, www.chimat.org.uk"]
+rake new_site["phe_chimat, public-health-england, www.chimat.org.uk"]
 ```
 
 ``abbr`` should be of the form:
 ```
-  <owning_organisation_abbreviation>_<abbreviated_site_name>
+<owning_organisation_abbreviation>_<abbreviated_site_name>
 ```
 
 Example for the "Obesity West Midlands" site which is owned by Public Health England:
 ```
-  phe_obesitywm
+phe_obesitywm
 ```
 
 The ``abbr`` is used in the URL for the site in the transition app. It is used as the primary key for a site and so shouldn't be changed once imported into the transition app, or a duplicate site will be created.
@@ -50,7 +50,7 @@ Extra organisations can be added later.
 
 `host` will be one of the hostnames that the site has, for example:
 ```
-  www.example.com
+www.example.com
 ```
 
 Aside: extra hostnames can be added later.
@@ -79,7 +79,7 @@ See the [Site configuration](#site-configuration) for more details about these a
 
 These perform some cursory validations of the site configuration files.
 ```
-  bundle exec rake validate:all
+bundle exec rake validate:all
 ```
 
 An option for a more thorough test of the config is to import it into the Transition app in development.


### PR DESCRIPTION
There are occasions where a site has not been crawled by The National Archives. In these cases we can use a stub timestamp. This adds docs to that effect. Also tidy up some whitespace in code blocks.

