### PR TITLE
Add student loans company

### DIFF
--- a/data/transition-sites/slc.yml
+++ b/data/transition-sites/slc.yml
@@ -1,0 +1,8 @@
+---
+site: slc
+whitehall_slug: student-loans-company
+homepage: https://www.gov.uk/government/organisations/student-loans-company
+tna_timestamp:  20181221130027
+host: www.slc.co.uk
+aliases:
+- slc.co.uk

--- a/data/transition-sites/slc_loanrepayment.yml
+++ b/data/transition-sites/slc_loanrepayment.yml
@@ -1,0 +1,8 @@
+---
+site: slc_loanrepayment
+whitehall_slug: student-loans-company
+homepage: https://www.gov.uk/government/organisations/repaying-your-student-loan
+tna_timestamp: 20180719091528
+host: www.studentloanrepayment.co.uk
+aliases:
+- studentloanrepayment.co.uk


### PR DESCRIPTION
Add transition configuration for Student Loans Company

They are transitioning:

* www.slc.co.uk
* www.studentloanrepayment.co.uk

SLC also wish to partially transition media.slc.co.uk, redirecting only http://media.slc.co.uk/repayment/qsg/index.html to https://www.gov.uk/repaying-your-student-loan while maintaining control of the rest of media.slc.co.uk. We've advised them, the best way to do that is to maintain control of the whole subdomain and set up the redirect for http://media.slc.co.uk/repayment/qsg/index.html  themselves rather than through transition.

[Trello](https://trello.com/c/bWiFXtib/261-student-loans-company-help-transition-2-of-their-websites-over-to-govuk)
