### PR TITLE
Remove sites relating to Policy Publisher

### DIFF
--- a/data/transition-sites/gds_alphagov_policy-publisher-preview.yml
+++ b/data/transition-sites/gds_alphagov_policy-publisher-preview.yml
@@ -1,8 +1,0 @@
----
-site: gds_alphagov_policy-publisher-preview
-whitehall_slug: government-digital-service
-homepage: https://policy-publisher.integration.publishing.service.gov.uk
-tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
-host: policy-publisher.preview.alphagov.co.uk
-global: =301 https://policy-publisher.integration.publishing.service.gov.uk
-global_redirect_append_path: true

--- a/data/transition-sites/gds_alphagov_policy-publisher.yml
+++ b/data/transition-sites/gds_alphagov_policy-publisher.yml
@@ -1,8 +1,0 @@
----
-site: gds_alphagov_policy-publisher
-whitehall_slug: government-digital-service
-homepage: https://policy-publisher.publishing.service.gov.uk
-tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
-host: policy-publisher.production.alphagov.co.uk
-global: =301 https://policy-publisher.publishing.service.gov.uk
-global_redirect_append_path: true


### PR DESCRIPTION
This application has been retired, as policy pages on GOV.UK have been
replaced by topic pages, and the publishing application has been
retired.