### PR TITLE
Add civil mediation site config

### DIFF
--- a/data/transition-sites/moj_civilmediation.yml
+++ b/data/transition-sites/moj_civilmediation.yml
@@ -1,0 +1,9 @@
+---
+site: moj_civilmediation
+whitehall_slug: ministry-of-justice
+homepage: https://civilmediation.org/results/
+tna_timestamp: 20160811143658
+host: civilmediation.justice.gov.uk
+aliases:
+- www.civilmediation.justice.gov.uk
+global: =301 https://civilmediation.org/results/


### PR DESCRIPTION
The new homepage domain will need adding to the redirection whitelist as it's
not a [*.gov.uk, *.nhs.uk or *.mod.uk subdomain](https://github.com/alphagov/bouncer/blob/d4c0daa8445028025a6d962a7f100ac1aa687d6a/lib/bouncer/outcome/base.rb#L19).

The TNA timestamp I've used is the most recent one - it won't ever be seen by
users anyway since this site is being configured as a global redirect.