### PR TITLE
Add config for passportapplication.service.gov.uk

### DIFF
--- a/data/transition-sites/directgov_passportapplication.yml
+++ b/data/transition-sites/directgov_passportapplication.yml
@@ -4,4 +4,4 @@ whitehall_slug: hm-passport-office
 homepage: https://passportapplication.service.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
 host: passportapplication.direct.gov.uk
-global: =301 https://passportapplication.service.gov.uk/ips-olc/
+global: =301 https://www.passport.service.gov.uk/help/old-service-unavailable

--- a/data/transition-sites/hmpo_passportapplication.yml
+++ b/data/transition-sites/hmpo_passportapplication.yml
@@ -1,0 +1,7 @@
+---
+site: hmpo_passportapplication
+whitehall_slug: hm-passport-office
+homepage: https://www.passport.service.gov.uk/help/old-service-unavailable
+tna_timestamp: 20140909112158
+host: passportapplication.service.gov.uk
+global: =301 https://www.passport.service.gov.uk/help/old-service-unavailable


### PR DESCRIPTION
Will be redirected to a help page telling users where to go next.

[Trello Card](https://trello.com/c/HVv59Lpl/985-redirect-for-old-online-passport-application-service)