### PR TITLE
Add config for DVSA site

### DIFF
--- a/data/transition-sites/dvsa_driverpracticaltest.yml
+++ b/data/transition-sites/dvsa_driverpracticaltest.yml
@@ -1,0 +1,7 @@
+---
+site: dvsa_driverpracticaltest
+whitehall_slug: driver-and-vehicle-standards-agency
+homepage: https://www.gov.uk/government/organisations/driver-and-vehicle-standards-agency
+tna_timestamp: 20100602114317
+host: driverpracticaltest.direct.gov.uk
+global: =301 https://www.gov.uk/book-driving-test


### PR DESCRIPTION
Adds a global redirect for https://driverpracticaltest.direct.gov.uk
to https://www.gov.uk/book-driving-test as requested by the DVSA.

Note that the most recent National Archive copy of the site
is from 2010 and doesn't look like the current one.  If DVSA
care about this they'll need to ask The National Archives to
do a fresh full site crawl before they shut off the old domain.

We can then update the timestamp here.

https://trello.com/c/XG70T7cS/986-redirect-for-driving-test-booking-service-dvsa