### PR TITLE
Add configuration for finddrivinginstructor.direct.gov.uk

### DIFF
--- a/data/transition-sites/directgov_finddrivinginstructor.yml
+++ b/data/transition-sites/directgov_finddrivinginstructor.yml
@@ -1,9 +1,0 @@
----
-site: directgov_finddrivinginstructor
-whitehall_slug: government-digital-service
-tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
-host: finddrivinginstructor.direct.gov.uk
-homepage_furl: www.gov.uk
-global: =410
-css: directgov
-homepage: https://www.gov.uk

--- a/data/transition-sites/dvsa_finddrivinginstructor.yml
+++ b/data/transition-sites/dvsa_finddrivinginstructor.yml
@@ -1,0 +1,7 @@
+---
+site: dvsa_finddrivinginstructor
+whitehall_slug: driver-and-vehicle-standards-agency
+homepage: https://www.gov.uk/government/organisations/driver-and-vehicle-standards-agency
+tna_timestamp: 20120905102739
+host: finddrivinginstructor.direct.gov.uk
+global: =301 https://www.gov.uk/find-driving-schools-and-lessons


### PR DESCRIPTION
This will be transition to https://www.gov.uk/find-driving-schools-and-lessons.

[Trello Card](https://trello.com/c/EjLHWPXX/1048-redirect-for-find-a-driving-instructor-service-dvsa)