### PR TITLE
Add Open Justice site config

### DIFF
--- a/data/transition-sites/moj_openjustice.yml
+++ b/data/transition-sites/moj_openjustice.yml
@@ -1,0 +1,9 @@
+---
+site: moj_openjustice
+whitehall_slug: ministry-of-justice
+homepage: https://www.gov.uk/government/organisations/ministry-of-justice/about/statistics
+tna_timestamp: 20190201115657
+host: open.justice.gov.uk
+aliases:
+- www.open.justice.gov.uk
+global: =301 https://www.gov.uk/government/organisations/ministry-of-justice/about/statistics


### PR DESCRIPTION
The Open Justice statistics site is being closed (or rather, should have been about a year ago!), and the best place for people to find out about MOJ stats is now on GOV.UK.

I've added the most recent timestamp, but people will probably never see the content because this is a global redirect.