### PR TITLE
Add end of life care intelligence

### DIFF
--- a/data/transition-sites/phe_eolc_int.yml
+++ b/data/transition-sites/phe_eolc_int.yml
@@ -1,0 +1,6 @@
+---
+site: phe_eolc_int
+whitehall_slug: public-health-england
+homepage: https://www.gov.uk/government/organisations/public-health-england
+tna_timestamp: 20190501131812
+host: www.endoflifecare-intelligence.org.uk


### PR DESCRIPTION
The PHE's end of life care intelligence site is being transitioned.

[Zendesk](https://govuk.zendesk.com/agent/tickets/3777608)