### PR TITLE
Add alias for end of life care

### DIFF
--- a/data/transition-sites/phe_eolc_int.yml
+++ b/data/transition-sites/phe_eolc_int.yml
@@ -4,3 +4,5 @@ whitehall_slug: public-health-england
 homepage: https://www.gov.uk/government/organisations/public-health-england
 tna_timestamp: 20190501131812
 host: www.endoflifecare-intelligence.org.uk
+aliases:
+- endoflifecare-intelligence.org.uk


### PR DESCRIPTION
End of life care intelligence should also have an alias for the
naked domain.