### PR TITLE
Add AKA redirect strategy for endoflifecare-intelligence.org.uk

### DIFF
--- a/data/transition-sites/phe_eolc_int.yml
+++ b/data/transition-sites/phe_eolc_int.yml
@@ -6,3 +6,4 @@ tna_timestamp: 20190501131812
 host: www.endoflifecare-intelligence.org.uk
 aliases:
 - endoflifecare-intelligence.org.uk
+special_redirect_strategy: via_aka


### PR DESCRIPTION
To aid transition Public Health England is using the AKA feature to test
out redirects prior to complete transition.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/3797363

@bevanloon I see you edited these files recently so I'm hoping you can review this, I think this is my first ever contribution to this repo so don't assume I've done anything right.