### PR TITLE
Update endoflifecare-intelligence homepage to collection

### DIFF
--- a/data/transition-sites/phe_eolc_int.yml
+++ b/data/transition-sites/phe_eolc_int.yml
@@ -1,7 +1,7 @@
 ---
 site: phe_eolc_int
 whitehall_slug: public-health-england
-homepage: https://www.gov.uk/government/organisations/public-health-england
+homepage: https://www.gov.uk/government/collections/palliative-and-end-of-life-care
 tna_timestamp: 20190501131812
 host: www.endoflifecare-intelligence.org.uk
 aliases:


### PR DESCRIPTION
As requested in https://govuk.zendesk.com/agent/tickets/3797363 the
homepage redirect should be the collection page rather than the
public-health-england homepage.