### PR TITLE
Remove www from national careers service homepage

### DIFF
--- a/data/transition-sites/esfa_nationalcareersservice.yml
+++ b/data/transition-sites/esfa_nationalcareersservice.yml
@@ -1,7 +1,7 @@
 ---
 site: esfa_nationalcareersservice
 whitehall_slug: education-and-skills-funding-agency
-homepage: http://www.nationalcareers.service.gov.uk
+homepage: http://nationalcareers.service.gov.uk
 tna_timestamp: 20190309013456
 host: nationalcareersservice.direct.gov.uk
 aliases:


### PR DESCRIPTION
It doesn't have one.

https://nationalcareers.service.gov.uk/
vs
https://www.nationalcareers.service.gov.uk/

https://govuk.zendesk.com/agent/tickets/3725749