### PR TITLE
Add fco_digital to Transition

### DIFF
--- a/data/transition-sites/fco_digital.yml
+++ b/data/transition-sites/fco_digital.yml
@@ -1,0 +1,10 @@
+---
+site: fco_digital
+whitehall_slug: foreign-commonwealth-office
+host: www.digital.fco.gov.uk
+aliases:
+- digital.fco.gov.uk
+tna_timestamp: 20130802095517
+homepage_furl: www.gov.uk/fco
+homepage: https://www.gov.uk/government/organisations/foreign-commonwealth-office
+css: foreign-commonwealth-office


### PR DESCRIPTION
- The FCO Digital team want to point this domain at the FCO homepage on
  GOV.UK.

They didn't specify whether it should be a global redirect but... I suspect it should.