### PR TITLE
Switch the fco_digital host to not start with `www`

### DIFF
--- a/data/transition-sites/fco_digital.yml
+++ b/data/transition-sites/fco_digital.yml
@@ -1,9 +1,9 @@
 ---
 site: fco_digital
 whitehall_slug: foreign-commonwealth-office
-host: www.digital.fco.gov.uk
+host: digital.fco.gov.uk
 aliases:
-- digital.fco.gov.uk
+- www.digital.fco.gov.uk
 tna_timestamp: 20130802095517
 homepage_furl: www.gov.uk/fco
 homepage: https://www.gov.uk/government/organisations/foreign-commonwealth-office


### PR DESCRIPTION
- The alias can start with `www` instead.
- I hypothesise that this is why Fastly is showing `Fastly error:
  unknown domain` when accessing www.digital.fco.gov.uk despite it
  correctly pointing at us via CNAME.