### PR TITLE
Add alias for www.businesssupport.gov.uk

### DIFF
--- a/data/transition-sites/beis_businesssupport.yml
+++ b/data/transition-sites/beis_businesssupport.yml
@@ -5,3 +5,5 @@ homepage: https://www.gov.uk/browse/business
 homepage_furl: www.gov.uk/beis
 tna_timestamp: 20200511152124
 host: www.businesssupport.gov.uk
+aliases:
+- businesssupport.gov.uk


### PR DESCRIPTION
Zendesk ticket: https://govuk.zendesk.com/agent/tickets/4088994

Alias added to stop  http://businesssupport.gov.uk and
https://businesssupport.gov.uk from returning an error page.