### PR TITLE
Switch sites to a global archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ Optional:
 * `extra_organisation_slugs` — additional organisations which own this site. Used for access control in Transition.
 * `homepage_furl` — friendly URL displayed on 404/410 pages. Should redirect to the `homepage`. Doesn't need to include 'http' or 'https'.
 * `aliases` — list of alias domains
-* `global` — set a global redirect or archive for all paths
+* `global` — set a global redirect or archive for all paths. There are two expected values for this:
+    - `=410` - this is a global archive, all site URLs will show a page saying the site has been archived
+    - `=301 <url>` - this is a global redirect, all site URLs will redirect to the given URL
 * `css` — a css class which determines the logo and brand colour used on 404/410 pages
 * `options` — used to list significant querystrings for canonicalisation like this: `--query-string first:second:third`. A significant querystring parameter is one which on the old website changes the content in a meaningful way - which we might therefore need to map to a different place. **Query string parameters should be specified in lowercase; uppercase parameters will not be preserved during canonicalisation.**
 * `global_redirect_append_path` — should the path the user supplied be appended

--- a/data/transition-sites/bis_biy.yml
+++ b/data/transition-sites/bis_biy.yml
@@ -4,6 +4,6 @@ whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20130430221758
 host: businessinyou.bis.gov.uk
-global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+global: =410
 aliases:
 - www.businessinyou.bis.gov.uk

--- a/data/transition-sites/ukti_makingitgreat.yml
+++ b/data/transition-sites/ukti_makingitgreat.yml
@@ -4,7 +4,7 @@ whitehall_slug: department-for-business-energy-and-industrial-strategy
 homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
 tna_timestamp: 20130923122628
 host: makeitingreatbritain.bis.gov.uk
-global: =301 https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+global: =410
 homepage_furl: www.gov.uk/ukti
 aliases:
 - www.makeitingreatbritain.bis.gov.uk


### PR DESCRIPTION
The department actually requested these pages to be global archives rather than global redirects.

It turns out that a "global archive" means setting the status code to 410: https://github.com/alphagov/transition/blob/f406c059e1a1785077ebf91afd9a631a081bf91a/lib/transition/import/site_yaml_file.rb#L53-L58

[Trello Card](https://trello.com/c/doczOPYo/2047-changes-to-transition-config-for-two-beis-sites)