### PR TITLE
Redirect all UK Gov in Wales domains to GOV.UK

### DIFF
--- a/data/transition-sites/walesoffice.yml
+++ b/data/transition-sites/walesoffice.yml
@@ -6,3 +6,7 @@ tna_timestamp: 20130129084240
 homepage_furl: www.gov.uk/wales
 homepage: https://www.gov.uk/government/organisations/office-of-the-secretary-of-state-for-wales
 css: wales-office
+aliases:
+- walesoffice.gov.uk
+- ukgovwales.gov.uk
+- www.ukgovwales.gov.uk


### PR DESCRIPTION
The Office of the Secretary of State for Wales now uses `ukgovwales.gov.uk` as their primary domain.

They are looking to reach citizens in Wales using social media advertising, and Facebook requires that their email domain matches that of their primary website. Given that, they need ukgovwales.gov.uk to redirect to their homepage on GOV.UK to allow these campaigns to direct users to the right place.

I also considered adding this as `moj_ukgovwales`, because we manage the Office of the Secretary of State for Wales's domains and mail (for reasons I don't fully understand), but saw that `walesoffice` already existed, pointed to the right place, and was responsible for the redirection of their previous domain.

Once this is approved and imported into Transition, I'll set up the CNAMEs and so forth.