### PR TITLE
Redirect api.gov.uk to www.api.gov.uk

### DIFF
--- a/data/transition-sites/gds_govuk-api.yml
+++ b/data/transition-sites/gds_govuk-api.yml
@@ -5,9 +5,8 @@ homepage: https://www.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: api.gov.uk
 aliases:
-  - www.api.gov.uk
   - apigov.uk
   - www.apigov.uk
 homepage_title: GOV.UK
-global: =301 https://www.gov.uk
+global: =301 https://www.api.gov.uk
 global_redirect_append_path: true


### PR DESCRIPTION
API Catalogue is now hosted by GitHub pages under the domain:
www.api.gov.uk.

Therefore, we change the transition config to redirect api.gov.uk
and its aliases to www.api.gov.uk.

Ref:
1. [Trello Card](https://trello.com/c/YP8EMD2l/1015-update-dns-for-apigovuk-to-point-at-the-api-catalog)
2. [DNS Change PR](https://github.com/alphagov/govuk-dns-config/pull/623)