### PR TITLE
Add MOJ GOV Facilities Services Ltd site config

### DIFF
--- a/data/transition-sites/moj_govfsl.yml
+++ b/data/transition-sites/moj_govfsl.yml
@@ -1,0 +1,9 @@
+---
+site: moj_govfsl
+whitehall_slug: gov-facility-services-limited
+homepage: https://www.gov.uk/government/organisations/gov-facility-services-limited
+tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
+host: www.govfsl.com
+aliases:
+- govfsl.com
+global: =301 https://www.gov.uk/government/organisations/gov-facility-services-limited


### PR DESCRIPTION
GOV Facilities Services Limited should be redirected to
https://www.gov.uk/government/organisations/gov-facility-services-limited.

I've added a stub National Archive timestamp as this site does not
appear to be in the national archives.