### PR TITLE
Add redirect for registers.service.gov.uk

### DIFF
--- a/data/transition-sites/gds_registers.yml
+++ b/data/transition-sites/gds_registers.yml
@@ -1,0 +1,8 @@
+---
+site: gds_registers
+whitehall_slug: government-digital-service
+homepage: https://www.gov.uk/government/organisations/government-digital-service
+homepage_furl: www.gov.uk/gds
+tna_timestamp: 20210205125927
+host: registers.service.gov.uk
+global: =301 https://data.gov.uk/dataset/a8f488fd-eaea-4176-92b0-6d0437b4d121/historical-gov-uk-registers


### PR DESCRIPTION
GOV.UK Registers is being deprecated and will be redirected to its
page on data.gov.uk.

The last snapshot of the website is https://webarchive.nationalarchives.gov.uk/20210205125927/https://www.registers.service.gov.uk/

Trello card: https://trello.com/c/ASsPYTrq/1110-redirect-registers-to-datagovuk-historical-page