### PR TITLE
Remove Academy for Justice Commissioning

### DIFF
--- a/data/transition-sites/moj_academy.yml
+++ b/data/transition-sites/moj_academy.yml
@@ -1,7 +1,0 @@
----
-site: moj_academy
-whitehall_slug: academy-for-justice-commissioning
-homepage: https://www.gov.uk/government/organisations/academy-for-justice-commissioning
-tna_timestamp: 20131204114654
-host: www.academyforjusticecommissioning.org.uk
-homepage_furl: www.gov.uk/moj


### PR DESCRIPTION
Removes Academy for Justice Commissioning from Transition app.

There are no existing redirects and the domain appears to have been bought by a porn site. Removing it will stop accidental clicking in Transition 