### PR TITLE
Migrate api.gov.uk to CDDO ownership

### DIFF
--- a/data/transition-sites/cddo_govuk-api.yml
+++ b/data/transition-sites/cddo_govuk-api.yml
@@ -1,6 +1,6 @@
 ---
-site: gds_govuk-api
-whitehall_slug: government-digital-service
+site: cddo_govuk-api
+whitehall_slug: central-digital-and-data-office
 homepage: https://www.gov.uk
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: api.gov.uk


### PR DESCRIPTION
As api.gov.uk is managed by the Data Standards Authority, under the
Central Digital and Data Office, we should update ownership information
accordingly.
