### PR TITLE
Add redirect for engineering.gov.uk

### DIFF
--- a/data/transition-sites/beis_engineering.yml
+++ b/data/transition-sites/beis_engineering.yml
@@ -1,0 +1,9 @@
+---
+site: beis_engineering
+whitehall_slug: department-for-business-energy-and-industrial-strategy
+homepage: https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy
+tna_timestamp: 20201107153234 
+host: www.engineering.gov.uk
+global: =410
+aliases:
+- engineering.gov.uk


### PR DESCRIPTION
This domain is no longer used and can be archived.