### PR TITLE
Add dhluc sites

### DIFF
--- a/data/transition-sites/dhluc_enterprisezones.yml
+++ b/data/transition-sites/dhluc_enterprisezones.yml
@@ -1,0 +1,6 @@
+---
+site: dhluc_enterprisezones
+whitehall_slug: department-for-levelling-up-housing-and-communities
+homepage: https://www.gov.uk/government/organisations/department-for-levelling-up-housing-and-communities
+tna_timestamp: 20220504062023
+host: enterprisezones.communities.gov.uk

--- a/data/transition-sites/dhluc_formscommunities.yml
+++ b/data/transition-sites/dhluc_formscommunities.yml
@@ -1,0 +1,6 @@
+---
+site: dhluc_formscommunities
+whitehall_slug: department-for-levelling-up-housing-and-communities
+homepage: https://www.gov.uk/government/organisations/department-for-levelling-up-housing-and-communities
+tna_timestamp: 20220913124535
+host: forms.communities.gov.uk


### PR DESCRIPTION
We've been requested to add the following subdomains to the transition app:

forms.communities.gov.uk
enterprisezones.communities.gov.uk

Neither have www. aliases

[Trello](https://trello.com/c/ZZr2VSmQ/307-5075233-add-2-sites-to-transition-manager-department-for-levelling-up-housing-communities-dluhc)