### PR TITLE
Add alphagov.co.uk and redirect it GDS org

### DIFF
--- a/data/transition-sites/gds_alphagov.yml
+++ b/data/transition-sites/gds_alphagov.yml
@@ -1,0 +1,9 @@
+---
+site: gds_alphagov
+whitehall_slug: government-digital-service
+homepage: https://www.gov.uk/government/organisations/government-digital-service
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: alphagov.co.uk
+aliases:
+- www.alphagov.co.uk
+global: =301 https://www.gov.uk/government/organisations/government-digital-service


### PR DESCRIPTION
Trello: https://trello.com/c/QPUKEiKs/2789-clean-up-dns-for-alphagovcouk-and-configure-for-bouncer

Despite there being many alphagov.co.uk entries in transition, there wasn't previously one for the apex domain. This configures transition so that requests to alphagov.co.uk and www.alphagov.co.uk redirect to the GDS page on GOV.UK

alphagov.co.uk was the original hostname that was used for gov.uk, prior to it transitioning to alpha.gov.uk, and demonstrated the initial achievement of the GDS team.

I looked on national archives and there is one entry from 2014 that is a redirect to a blog: https://webarchive.nationalarchives.gov.uk/ukgwa/*/www.alphagov.co.uk so I decided it was not appropriate to flag the site as in national archives, given the data is not useful.

Right now alphagov.co.uk points to an IP address that doesn't respond, this change is to restore it to a working hostname.