### PR TITLE
Add redirects for domains.gov.uk

### DIFF
--- a/data/transition-sites/cddo_domains.yml
+++ b/data/transition-sites/cddo_domains.yml
@@ -1,0 +1,9 @@
+---
+site: cddo_domains
+whitehall_slug: central-digital-and-data-office
+homepage: https://www.gov.uk/government/groups/domain-management-team
+global: =301 https://www.gov.uk/government/groups/domain-management-team
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: domains.gov.uk
+aliases:
+- www.domains.gov.uk


### PR DESCRIPTION
This domain is used by the Domain Management team in CDDO.

They've asked us to redirect it to their page on the main GOV.UK site.

Zendesk: https://govuk.zendesk.com/agent/tickets/5131081