### PR TITLE
Add redirect to helpforhouseholds campaign site

### DIFF
--- a/data/transition-sites/helpforhouseholds.yml
+++ b/data/transition-sites/helpforhouseholds.yml
@@ -1,0 +1,9 @@
+---
+site: helpforhouseholds
+whitehall_slug: cabinet-office
+homepage: https://helpforhouseholds.campaign.gov.uk
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: helpforhouseholds.gov.uk
+aliases:
+- www.helpforhouseholds.gov.uk
+global: =301 https://helpforhouseholds.campaign.gov.uk


### PR DESCRIPTION
https://helpforhouseholds.gov.uk no longer resolves. We need it to redirect to https://helpforhouseholds.campaign.gov.uk.

Zendesk: https://govuk.zendesk.com/agent/tickets/5149911