### PR TITLE
Reslug department for culture media and sport

### DIFF
--- a/data/transition-sites/dcms.yml
+++ b/data/transition-sites/dcms.yml
@@ -1,12 +1,12 @@
 ---
 site: dcms
-whitehall_slug: department-for-digital-culture-media-sport
+whitehall_slug: department-for-culture-media-and-sport
 host: www.culture.gov.uk
 tna_timestamp: 20121204113822
 homepage_furl: www.gov.uk/dcms
-homepage: https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport
+homepage: https://www.gov.uk/government/organisations/department-for-culture-media-and-sport
 aliases:
 - culture.gov.uk
 - www.dcms.gov.uk
 - dcms.gov.uk
-css: department-for-digital-culture-media-sport
+css: department-for-culture-media-and-sport


### PR DESCRIPTION
This recently changed from the department for digital, culture, media and sport and we have been asked to make sure that dcms.gov.uk redirects to the new homepage.

[Trello](https://trello.com/c/hhUADMRZ/581-update-transition-config-for-dcms)

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
