### PR TITLE
adjust gds careers redirect so it's global

### DIFF
--- a/data/transition-sites/gds_career.yml
+++ b/data/transition-sites/gds_career.yml
@@ -2,5 +2,6 @@
 site: gds_career
 whitehall_slug: government-digital-service
 homepage: https://www.gov.uk/government/organisations/government-digital-service
+global: =301 https://www.civil-service-careers.gov.uk/departments/gds-hub/
 tna_timestamp: 20201010101010 # Stub timestamp - site is not in TNA
 host: gdscareers.gov.uk


### PR DESCRIPTION
This should mean that all paths redirect to the given page

Trello - https://trello.com/c/pWbH2Z31/750-redirect-gdscareersgovuk-pages-to-the-new-careers-page

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
