### PR TITLE
Add govuk-kubernetes-cluster-user-docs to Transition Config

### DIFF
--- a/data/transition-sites/gds_govuk-kubernetes-cluster-user-docs.yml
+++ b/data/transition-sites/gds_govuk-kubernetes-cluster-user-docs.yml
@@ -1,0 +1,7 @@
+---
+site: gds_govuk-kubernetes-cluster-user-docs
+whitehall_slug: government-digital-service
+homepage: https://docs.publishing.service.gov.uk/kubernetes/
+tna_timestamp: 20201010101010 # Stub timestamp - site not in TNA
+host: govuk-kubernetes-cluster-user-docs.publishing.service.gov.uk
+global: =301 https://docs.publishing.service.gov.uk/kubernetes/


### PR DESCRIPTION
https://govuk-kubernetes-cluster-user-docs.publishing.service.gov.uk/ is being retired. Its contents have been moved to
https://docs.publishing.service.gov.uk/kubernetes/

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
