### PR TITLE
Remove www.siriusprogramme.com alias

### DIFF
--- a/data/transition-sites/ukti_sirius.yml
+++ b/data/transition-sites/ukti_sirius.yml
@@ -6,5 +6,3 @@ tna_timestamp: 20150101010101
 host: www.siriusprogramme.ukti.gov.uk
 homepage_furl: www.gov.uk/ukti
 global: =301 https://www.gov.uk/government/collections/sirius-programme-for-graduate-entrepreneurs
-aliases:
-- www.siriusprogramme.com


### PR DESCRIPTION
`dig siriusprogramme.com`, `dig aka.siriusprogramme.com` and `dig www.siriusprogramme.com` return NXDOMAIN, and there’s no WHOIS record for siriusprogramme.com anymore either.
There’s no domain there for us to attach a TXT record to, which is required to manually verify domains to use them in Fastly.

The addition of this domain is blocking govuk-fastly terraform apply as this project fetches a list of domains from Transition, here: https://transition.publishing.service.gov.uk/hosts.json

We are removing it from the config to unblock TF apply.  
The records will need to be separately updated in Transition as the script only adds sites: https://github.com/alphagov/transition/pull/1408

Site in Transition: https://transition.publishing.service.gov.uk/sites/ukti_sirius

---
This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
